### PR TITLE
feat: add Image pixel buffer and image I/O (PPM/EXR/PNG)

### DIFF
--- a/include/art/Camera.hpp
+++ b/include/art/Camera.hpp
@@ -10,16 +10,19 @@ namespace art {
 
 class ART_API Camera {
    public:
-    static utils::Isometry lookAt(const Point& position, const Point& target,
-                                  const Point& up);
+    static auto look_at(const Point &position,
+                        const Point &target,
+                        const Point &up) -> utils::Isometry;
 
-    Camera(const utils::Isometry& ct) : _camera_transform(ct) {}
+    Camera(const utils::Isometry &ct) : m_camera_transform(ct) {}
 
-    Image render(size_t nx, size_t ny, objects::SceneNode& node) const;
+    auto render(size_t nx, size_t ny, objects::SceneNode &node) const -> Image;
 
-    const utils::Isometry& transform() const { return _camera_transform; }
+    auto transform() const -> const utils::Isometry & {
+        return m_camera_transform;
+    }
 
    private:
-    utils::Isometry _camera_transform;
+    utils::Isometry m_camera_transform;
 };
-}  // namespace art
+} // namespace art

--- a/include/art/Image.hpp
+++ b/include/art/Image.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#if !defined(ART_IMAGE_HPP)
+#define ART_IMAGE_HPP
 
 #include <array>
 #include <atomic>
@@ -35,9 +36,9 @@ class ART_API Image {
 
     // Move-only (std::atomic members prevent implicit copy/move).
     Image(const Image &) = delete;
-    Image &operator=(const Image &) = delete;
+    auto operator=(const Image &) -> Image & = delete;
     Image(Image &&other) noexcept;
-    Image &operator=(Image &&other) noexcept;
+    auto operator=(Image &&other) noexcept -> Image &;
 
     // ── Dimensions ──
 
@@ -125,32 +126,34 @@ class ART_API Image {
     void clear();
 
   private:
-    size_t _width = 0;
-    size_t _height = 0;
-    PixelFormat _format = PixelFormat::RGBAF32;
+    size_t m_width = 0;
+    size_t m_height = 0;
+    PixelFormat m_format = PixelFormat::RGBAF32;
 
     // Pixel storage: 4 floats per pixel (R, G, B, A), row-major.
-    std::vector<float> _pixels;
+    std::vector<float> m_pixels;
 
     // Per-pixel weight accumulator for add_sample mode.
     // Empty when using set_pixel mode only.
-    std::vector<float> _weights;
+    std::vector<float> m_weights;
 
-    // Resolved (normalized) cache — lazily computed from _pixels/_weights.
-    mutable std::vector<float> _resolved;
-    mutable uint64_t _resolved_version = 0;
+    // Resolved (normalized) cache — lazily computed from m_pixels/m_weights.
+    mutable std::vector<float> m_resolved;
+    mutable uint64_t m_resolved_version = 0;
 
     // Thread-safe progress and versioning.
-    std::atomic<size_t> _pixels_completed = 0;
-    std::atomic<uint64_t> _version = 0;
+    std::atomic<size_t> m_pixels_completed = 0;
+    std::atomic<uint64_t> m_version = 0;
 
-    UpdateCallback _on_update;
+    UpdateCallback m_on_update;
 
     // ── Internal helpers ──
 
-    auto _pixel_index(size_t x, size_t y) const -> size_t;
-    void _notify(size_t x, size_t y, size_t w, size_t h);
-    void _ensure_resolved() const;
+    auto pixel_index(size_t x, size_t y) const -> size_t;
+    void notify(size_t x, size_t y, size_t w, size_t h);
+    void ensure_resolved() const;
 };
 
 } // namespace art
+
+#endif // ART_IMAGE_HPP

--- a/include/art/Image.hpp
+++ b/include/art/Image.hpp
@@ -1,5 +1,156 @@
 #pragma once
 
+#include <array>
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <optional>
+#include <span>
+#include <vector>
+
+#include "art/export.hpp"
+
 namespace art {
-class Image {};
-}  // namespace art
+
+/// PBRT Film-style pixel buffer with sample accumulation.
+///
+/// Supports two modes of pixel writing:
+///   1. Direct: set_pixel() sets the final color value.
+///   2. Accumulation: add_sample() accumulates weighted color contributions;
+///      resolved_pixel() divides by total weight for the final value.
+///
+/// Thread safety: version() and progress counters are atomic. Write methods
+/// (set_pixel, add_sample, set_tile, set_scanline) are NOT synchronized —
+/// callers must ensure no two threads write the same pixel concurrently.
+/// The on_update callback is called from the writing thread.
+class ART_API Image {
+  public:
+    enum class PixelFormat { RGBA8, RGBAF32 };
+
+    Image() = default;
+    Image(size_t width,
+          size_t height,
+          PixelFormat format = PixelFormat::RGBAF32);
+
+    // Move-only (std::atomic members prevent implicit copy/move).
+    Image(const Image &) = delete;
+    Image &operator=(const Image &) = delete;
+    Image(Image &&other) noexcept;
+    Image &operator=(Image &&other) noexcept;
+
+    // ── Dimensions ──
+
+    auto width() const -> size_t;
+    auto height() const -> size_t;
+    auto format() const -> PixelFormat;
+
+    // ── Direct pixel access ──
+
+    void
+        set_pixel(size_t x, size_t y, float r, float g, float b, float a = 1.f);
+    auto pixel(size_t x, size_t y) const -> std::array<float, 4>;
+
+    // ── Sample accumulation (PBRT Film pattern) ──
+    //
+    // An Integrator calls add_sample() for each path/light sample.
+    // The Image accumulates weighted color contributions and tracks
+    // the total weight per pixel for correct normalization.
+
+    void add_sample(size_t x,
+                    size_t y,
+                    float r,
+                    float g,
+                    float b,
+                    float weight = 1.f);
+
+    /// Get the current (normalized) color at a pixel.
+    /// For add_sample mode: divides accumulated color by total weight.
+    /// For set_pixel mode: returns the last-set value.
+    auto resolved_pixel(size_t x, size_t y) const -> std::array<float, 4>;
+
+    // ── Bulk access ──
+
+    /// Set a full scanline (row y). Data must be width()*4 floats (RGBA).
+    void set_scanline(size_t y, std::span<const float> rgba_row);
+
+    /// Set a rectangular tile. Data must be w*h*4 floats (RGBA), row-major.
+    void set_tile(size_t x,
+                  size_t y,
+                  size_t w,
+                  size_t h,
+                  std::span<const float> rgba_data);
+
+    /// Full resolved pixel buffer (row-major, 4 floats per pixel).
+    /// For set_pixel mode: direct values.
+    /// For add_sample mode: normalized (resolved) values.
+    auto pixels() const -> std::span<const float>;
+
+    /// Raw accumulated buffer (un-normalized). For internal use
+    /// or advanced consumers that want to apply their own normalization.
+    auto raw_pixels() const -> std::span<const float>;
+
+    // ── Progress tracking ──
+    // Thread-safe (atomic). The render loop increments this.
+
+    void increment_progress(size_t count = 1);
+    auto pixels_completed() const -> size_t;
+    auto total_pixels() const -> size_t;
+    auto progress_fraction() const -> float;
+
+    // ── Dirty tracking + notification ──
+
+    /// Version is bumped on every write operation.
+    auto version() const -> uint64_t;
+
+    /// Callback invoked after each write with the dirty region.
+    /// Called from the writing thread — must be lightweight.
+    using UpdateCallback =
+        std::function<void(size_t x, size_t y, size_t w, size_t h)>;
+    void set_on_update(UpdateCallback cb);
+
+    // ── Conversion ──
+
+    /// Produce an RGBA8 buffer (for saving to 8-bit formats).
+    /// Applies the given exposure (EV stops) and gamma.
+    auto to_rgba8(float exposure = 0.f, float gamma = 2.2f) const
+        -> std::vector<uint8_t>;
+
+    // ── State queries ──
+
+    /// True if add_sample() has been called (weight buffer is allocated).
+    auto is_accumulation_mode() const -> bool;
+
+    /// Clear all pixel data and weights to zero. Dimensions unchanged.
+    void clear();
+
+  private:
+    size_t _width = 0;
+    size_t _height = 0;
+    PixelFormat _format = PixelFormat::RGBAF32;
+
+    // Pixel storage: 4 floats per pixel (R, G, B, A), row-major.
+    std::vector<float> _pixels;
+
+    // Per-pixel weight accumulator for add_sample mode.
+    // Empty when using set_pixel mode only.
+    std::vector<float> _weights;
+
+    // Resolved (normalized) cache — lazily computed from _pixels/_weights.
+    mutable std::vector<float> _resolved;
+    mutable uint64_t _resolved_version = 0;
+
+    // Thread-safe progress and versioning.
+    std::atomic<size_t> _pixels_completed = 0;
+    std::atomic<uint64_t> _version = 0;
+
+    UpdateCallback _on_update;
+
+    // ── Internal helpers ──
+
+    auto _pixel_index(size_t x, size_t y) const -> size_t;
+    void _notify(size_t x, size_t y, size_t w, size_t h);
+    void _ensure_resolved() const;
+};
+
+} // namespace art

--- a/include/art/io/image_io.hpp
+++ b/include/art/io/image_io.hpp
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <expected>
+#include <filesystem>
+#include <string>
+
+#include "art/Image.hpp"
+#include "art/export.hpp"
+
+namespace art::io {
+
+// ── Format enum ──
+
+enum class ImageFormat {
+    EXR, // OpenEXR via tinyexr — HDR float, lossless
+    PNG, // PNG via stb_image — 8-bit LDR, lossless
+    PPM, // Portable PixMap — 8-bit, no dependency, always available
+    Auto, // Deduce from file extension
+};
+
+// ── Save options (for LDR conversion) ──
+
+struct SaveOptions {
+    float exposure = 0.f; // EV stops
+    float gamma = 2.2f; // gamma curve
+};
+
+// ── Generic load/save (dispatch on extension or explicit format) ──
+
+/// Load an image from any supported format.
+/// Format::Auto deduces from extension: .exr -> EXR, .png -> PNG, .ppm -> PPM.
+ART_API auto load(const std::filesystem::path &path,
+                  ImageFormat format = ImageFormat::Auto)
+    -> std::expected<Image, std::string>;
+
+/// Save an image to any supported format.
+/// For LDR formats (PNG, PPM): applies tone mapping (exposure + gamma).
+/// For HDR formats (EXR): writes float data directly.
+ART_API auto save(const std::filesystem::path &path,
+                  const Image &image,
+                  ImageFormat format = ImageFormat::Auto,
+                  const SaveOptions &opts = {})
+    -> std::expected<void, std::string>;
+
+// ── Query which formats are compiled in ──
+
+ART_API auto has_exr_support() -> bool;
+ART_API auto has_png_support() -> bool;
+ART_API auto has_ppm_support() -> bool; // always true
+
+// ── Format-specific functions ──
+
+namespace exr {
+    ART_API auto load(const std::filesystem::path &path)
+        -> std::expected<Image, std::string>;
+    ART_API auto save(const std::filesystem::path &path, const Image &image)
+        -> std::expected<void, std::string>;
+} // namespace exr
+
+namespace png {
+    ART_API auto load(const std::filesystem::path &path)
+        -> std::expected<Image, std::string>;
+    ART_API auto save(const std::filesystem::path &path,
+                      const Image &image,
+                      const SaveOptions &opts = {})
+        -> std::expected<void, std::string>;
+} // namespace png
+
+namespace ppm {
+    ART_API auto load(const std::filesystem::path &path)
+        -> std::expected<Image, std::string>;
+    ART_API auto save(const std::filesystem::path &path,
+                      const Image &image,
+                      const SaveOptions &opts = {})
+        -> std::expected<void, std::string>;
+} // namespace ppm
+
+} // namespace art::io

--- a/include/art/io/image_io.hpp
+++ b/include/art/io/image_io.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#if !defined(ART_IO_IMAGE_IO_HPP)
+#define ART_IO_IMAGE_IO_HPP
 
 #include <expected>
 #include <filesystem>
@@ -76,3 +77,5 @@ namespace ppm {
 } // namespace ppm
 
 } // namespace art::io
+
+#endif // ART_IO_IMAGE_IO_HPP

--- a/meson.build
+++ b/meson.build
@@ -23,6 +23,23 @@ TBB_dep = dependency('tbb')
 required_deps = [zipper_dep]
 internal_deps = [spdlog_dep] + required_deps
 
+# Optional image I/O dependencies
+io_cpp_args = []
+
+if get_option('exr')
+  tinyexr_proj = subproject('tinyexr')
+  tinyexr_dep = tinyexr_proj.get_variable('tinyexr_dep')
+  internal_deps += tinyexr_dep
+  io_cpp_args += '-DART_HAS_EXR=1'
+endif
+
+if get_option('png')
+  stb_proj = subproject('stb')
+  stb_dep = stb_proj.get_variable('stb_dep')
+  internal_deps += stb_dep
+  io_cpp_args += '-DART_HAS_PNG=1'
+endif
+
 lib_sources = [
     'src/Point.cpp'
 
@@ -37,6 +54,11 @@ lib_sources = [
     ,'src/geometry/Line.cpp'
     ,'src/Rational.cpp'
     ,'src/Ray.cpp'
+    ,'src/Image.cpp'
+    ,'src/io/image_io.cpp'
+    ,'src/io/ppm.cpp'
+    ,'src/io/exr.cpp'
+    ,'src/io/png.cpp'
 ]
 
 include_dirs = [include_directories('include')]
@@ -50,7 +72,7 @@ art_headers_dep = declare_dependency(
 art_lib = library('art', lib_sources,
   include_directories: include_dirs,
   dependencies: internal_deps,
-  cpp_args: ['-DART_EXPORTS'],
+  cpp_args: ['-DART_EXPORTS'] + io_cpp_args,
   gnu_symbol_visibility: 'hidden')
 
 # Full dependency (headers + library linking)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,2 +1,4 @@
 option('testing', type : 'boolean', value : true, description : 'Enable tests')
 option('examples', type : 'boolean', value : true, description : 'Build examples')
+option('exr', type : 'boolean', value : false, description : 'EXR image I/O via tinyexr')
+option('png', type : 'boolean', value : false, description : 'PNG image I/O via stb_image')

--- a/src/Camera.cpp
+++ b/src/Camera.cpp
@@ -1,14 +1,14 @@
 #include "art/Camera.hpp"
 
-#include <iostream>
 #include <zipper/transform/transform.hpp>
 
 #include "art/Ray.hpp"
 #include "art/utils/AffineTransform.hpp"
 namespace art {
 
-utils::Isometry Camera::lookAt(const Point& position, const Point& target,
-                                const Point& up) {
+utils::Isometry Camera::lookAt(const Point &position,
+                               const Point &target,
+                               const Point &up) {
     // Convert Points to Vector3d (divides numerator by denominator)
     Vector3d eye = position;
     Vector3d center = target;
@@ -16,7 +16,9 @@ utils::Isometry Camera::lookAt(const Point& position, const Point& target,
     return zipper::transform::look_at(eye, center, up_vec);
 }
 
-Image Camera::render(size_t nx, size_t ny, objects::SceneNode& node) const {
+Image Camera::render(size_t nx, size_t ny, objects::SceneNode &node) const {
+    Image image(nx, ny);
+
     Ray ray;
     ray.origin = Point(0, 0, 0);
 
@@ -38,13 +40,15 @@ Image Camera::render(size_t nx, size_t ny, objects::SceneNode& node) const {
 
             std::optional<Intersection> isect;
             if (node.intersect(ray, isect)) {
-                std::cout << "o";
+                // White for hits (until materials/lights exist)
+                image.set_pixel(i, j, 1.f, 1.f, 1.f, 1.f);
             } else {
-                std::cout << ".";
+                // Black for misses
+                image.set_pixel(i, j, 0.f, 0.f, 0.f, 1.f);
             }
+            image.increment_progress();
         }
-        std::cout << std::endl;
     }
-    return {};
+    return image;
 }
-}  // namespace art
+} // namespace art

--- a/src/Camera.cpp
+++ b/src/Camera.cpp
@@ -6,9 +6,9 @@
 #include "art/utils/AffineTransform.hpp"
 namespace art {
 
-utils::Isometry Camera::lookAt(const Point &position,
-                               const Point &target,
-                               const Point &up) {
+auto Camera::look_at(const Point &position,
+                     const Point &target,
+                     const Point &up) -> utils::Isometry {
     // Convert Points to Vector3d (divides numerator by denominator)
     Vector3d eye = position;
     Vector3d center = target;
@@ -16,13 +16,14 @@ utils::Isometry Camera::lookAt(const Point &position,
     return zipper::transform::look_at(eye, center, up_vec);
 }
 
-Image Camera::render(size_t nx, size_t ny, objects::SceneNode &node) const {
+auto Camera::render(size_t nx, size_t ny, objects::SceneNode &node) const
+    -> Image {
     Image image(nx, ny);
 
     Ray ray;
     ray.origin = Point(0, 0, 0);
 
-    auto CI = _camera_transform.inverse();
+    auto CI = m_camera_transform.inverse();
 
     ray.origin.homogeneous() = CI.to_matrix() * ray.origin.homogeneous();
 

--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -1,70 +1,73 @@
 #include "art/Image.hpp"
 
 #include <algorithm>
-#include <cassert>
 #include <cmath>
+#include <utility>
 
 namespace art {
 
 Image::Image(size_t width, size_t height, PixelFormat format)
-  : _width(width), _height(height), _format(format),
-    _pixels(width * height * 4, 0.f) {}
+  : m_width(width), m_height(height), m_format(format),
+    m_pixels(width * height * 4, 0.f) {}
 
 Image::Image(Image &&other) noexcept
-  : _width(other._width), _height(other._height), _format(other._format),
-    _pixels(std::move(other._pixels)), _weights(std::move(other._weights)),
-    _resolved(std::move(other._resolved)),
-    _resolved_version(other._resolved_version),
-    _pixels_completed(other._pixels_completed.load(std::memory_order_relaxed)),
-    _version(other._version.load(std::memory_order_relaxed)),
-    _on_update(std::move(other._on_update)) {
-    other._width = 0;
-    other._height = 0;
+  : m_width(other.m_width), m_height(other.m_height), m_format(other.m_format),
+    m_pixels(std::move(other.m_pixels)), m_weights(std::move(other.m_weights)),
+    m_resolved(std::move(other.m_resolved)),
+    m_resolved_version(other.m_resolved_version),
+    m_pixels_completed(
+        other.m_pixels_completed.load(std::memory_order_relaxed)),
+    m_version(other.m_version.load(std::memory_order_relaxed)),
+    m_on_update(std::move(other.m_on_update)) {
+    other.m_width = 0;
+    other.m_height = 0;
 }
 
-Image &Image::operator=(Image &&other) noexcept {
+auto Image::operator=(Image &&other) noexcept -> Image & {
     if (this != &other) {
-        _width = other._width;
-        _height = other._height;
-        _format = other._format;
-        _pixels = std::move(other._pixels);
-        _weights = std::move(other._weights);
-        _resolved = std::move(other._resolved);
-        _resolved_version = other._resolved_version;
-        _pixels_completed.store(
-            other._pixels_completed.load(std::memory_order_relaxed),
+        m_width = other.m_width;
+        m_height = other.m_height;
+        m_format = other.m_format;
+        m_pixels = std::move(other.m_pixels);
+        m_weights = std::move(other.m_weights);
+        m_resolved = std::move(other.m_resolved);
+        m_resolved_version = other.m_resolved_version;
+        m_pixels_completed.store(
+            other.m_pixels_completed.load(std::memory_order_relaxed),
             std::memory_order_relaxed);
-        _version.store(other._version.load(std::memory_order_relaxed),
-                       std::memory_order_relaxed);
-        _on_update = std::move(other._on_update);
-        other._width = 0;
-        other._height = 0;
+        m_version.store(other.m_version.load(std::memory_order_relaxed),
+                        std::memory_order_relaxed);
+        m_on_update = std::move(other.m_on_update);
+        other.m_width = 0;
+        other.m_height = 0;
     }
     return *this;
 }
 
 // ── Dimensions ──
 
-auto Image::width() const -> size_t { return _width; }
-auto Image::height() const -> size_t { return _height; }
-auto Image::format() const -> PixelFormat { return _format; }
+auto Image::width() const -> size_t { return m_width; }
+auto Image::height() const -> size_t { return m_height; }
+auto Image::format() const -> PixelFormat { return m_format; }
 
 // ── Direct pixel access ──
 
 void Image::set_pixel(size_t x, size_t y, float r, float g, float b, float a) {
-    size_t idx = _pixel_index(x, y);
-    _pixels[idx + 0] = r;
-    _pixels[idx + 1] = g;
-    _pixels[idx + 2] = b;
-    _pixels[idx + 3] = a;
-    _version.fetch_add(1, std::memory_order_release);
-    _notify(x, y, 1, 1);
+    size_t idx = pixel_index(x, y);
+    m_pixels[idx + 0] = r;
+    m_pixels[idx + 1] = g;
+    m_pixels[idx + 2] = b;
+    m_pixels[idx + 3] = a;
+    m_version.fetch_add(1, std::memory_order_release);
+    notify(x, y, 1, 1);
 }
 
 auto Image::pixel(size_t x, size_t y) const -> std::array<float, 4> {
-    size_t idx = _pixel_index(x, y);
-    return {
-        _pixels[idx + 0], _pixels[idx + 1], _pixels[idx + 2], _pixels[idx + 3]};
+    size_t idx = pixel_index(x, y);
+    return {m_pixels[idx + 0],
+            m_pixels[idx + 1],
+            m_pixels[idx + 2],
+            m_pixels[idx + 3]};
 }
 
 // ── Sample accumulation ──
@@ -76,48 +79,48 @@ void Image::add_sample(size_t x,
                        float b,
                        float weight) {
     // Lazily allocate weight buffer on first use.
-    if (_weights.empty()) { _weights.resize(_width * _height, 0.f); }
-    size_t idx = _pixel_index(x, y);
-    size_t pidx = (y * _width + x);
-    _pixels[idx + 0] += r * weight;
-    _pixels[idx + 1] += g * weight;
-    _pixels[idx + 2] += b * weight;
-    _pixels[idx + 3] += weight; // alpha accumulates weight for now
-    _weights[pidx] += weight;
-    _version.fetch_add(1, std::memory_order_release);
-    _notify(x, y, 1, 1);
+    if (m_weights.empty()) { m_weights.resize(m_width * m_height, 0.f); }
+    size_t idx = pixel_index(x, y);
+    size_t pidx = (y * m_width + x);
+    m_pixels[idx + 0] += r * weight;
+    m_pixels[idx + 1] += g * weight;
+    m_pixels[idx + 2] += b * weight;
+    m_pixels[idx + 3] += weight; // alpha accumulates weight for now
+    m_weights[pidx] += weight;
+    m_version.fetch_add(1, std::memory_order_release);
+    notify(x, y, 1, 1);
 }
 
 auto Image::resolved_pixel(size_t x, size_t y) const -> std::array<float, 4> {
-    size_t idx = _pixel_index(x, y);
+    size_t idx = pixel_index(x, y);
 
-    if (_weights.empty()) {
+    if (m_weights.empty()) {
         // Direct mode — return as-is.
-        return {_pixels[idx + 0],
-                _pixels[idx + 1],
-                _pixels[idx + 2],
-                _pixels[idx + 3]};
+        return {m_pixels[idx + 0],
+                m_pixels[idx + 1],
+                m_pixels[idx + 2],
+                m_pixels[idx + 3]};
     }
 
     // Accumulation mode — normalize by weight.
-    size_t pidx = (y * _width + x);
-    float w = _weights[pidx];
+    size_t pidx = (y * m_width + x);
+    float w = m_weights[pidx];
     if (w == 0.f) { return {0.f, 0.f, 0.f, 0.f}; }
     float inv_w = 1.f / w;
-    return {_pixels[idx + 0] * inv_w,
-            _pixels[idx + 1] * inv_w,
-            _pixels[idx + 2] * inv_w,
+    return {m_pixels[idx + 0] * inv_w,
+            m_pixels[idx + 1] * inv_w,
+            m_pixels[idx + 2] * inv_w,
             1.f};
 }
 
 // ── Bulk access ──
 
 void Image::set_scanline(size_t y, std::span<const float> rgba_row) {
-    assert(rgba_row.size() >= _width * 4);
-    size_t idx = _pixel_index(0, y);
-    std::copy_n(rgba_row.data(), _width * 4, _pixels.data() + idx);
-    _version.fetch_add(1, std::memory_order_release);
-    _notify(0, y, _width, 1);
+    if (rgba_row.size() < m_width * 4) { return; }
+    size_t idx = pixel_index(0, y);
+    std::copy_n(rgba_row.data(), m_width * 4, m_pixels.data() + idx);
+    m_version.fetch_add(1, std::memory_order_release);
+    notify(0, y, m_width, 1);
 }
 
 void Image::set_tile(size_t x,
@@ -125,36 +128,36 @@ void Image::set_tile(size_t x,
                      size_t w,
                      size_t h,
                      std::span<const float> rgba_data) {
-    assert(rgba_data.size() >= w * h * 4);
+    if (rgba_data.size() < w * h * 4) { return; }
     for (size_t row = 0; row < h; ++row) {
-        size_t dst_idx = _pixel_index(x, y + row);
+        size_t dst_idx = pixel_index(x, y + row);
         size_t src_idx = row * w * 4;
         std::copy_n(
-            rgba_data.data() + src_idx, w * 4, _pixels.data() + dst_idx);
+            rgba_data.data() + src_idx, w * 4, m_pixels.data() + dst_idx);
     }
-    _version.fetch_add(1, std::memory_order_release);
-    _notify(x, y, w, h);
+    m_version.fetch_add(1, std::memory_order_release);
+    notify(x, y, w, h);
 }
 
 auto Image::pixels() const -> std::span<const float> {
-    if (_weights.empty()) { return _pixels; }
-    _ensure_resolved();
-    return _resolved;
+    if (m_weights.empty()) { return m_pixels; }
+    ensure_resolved();
+    return m_resolved;
 }
 
-auto Image::raw_pixels() const -> std::span<const float> { return _pixels; }
+auto Image::raw_pixels() const -> std::span<const float> { return m_pixels; }
 
 // ── Progress tracking ──
 
 void Image::increment_progress(size_t count) {
-    _pixels_completed.fetch_add(count, std::memory_order_relaxed);
+    m_pixels_completed.fetch_add(count, std::memory_order_relaxed);
 }
 
 auto Image::pixels_completed() const -> size_t {
-    return _pixels_completed.load(std::memory_order_relaxed);
+    return m_pixels_completed.load(std::memory_order_relaxed);
 }
 
-auto Image::total_pixels() const -> size_t { return _width * _height; }
+auto Image::total_pixels() const -> size_t { return m_width * m_height; }
 
 auto Image::progress_fraction() const -> float {
     size_t total = total_pixels();
@@ -165,17 +168,17 @@ auto Image::progress_fraction() const -> float {
 // ── Dirty tracking + notification ──
 
 auto Image::version() const -> uint64_t {
-    return _version.load(std::memory_order_acquire);
+    return m_version.load(std::memory_order_acquire);
 }
 
-void Image::set_on_update(UpdateCallback cb) { _on_update = std::move(cb); }
+void Image::set_on_update(UpdateCallback cb) { m_on_update = std::move(cb); }
 
 // ── Conversion ──
 
 auto Image::to_rgba8(float exposure, float gamma) const
     -> std::vector<uint8_t> {
     auto src = pixels(); // resolved if in accumulation mode
-    size_t num_pixels = _width * _height;
+    size_t num_pixels = m_width * m_height;
     std::vector<uint8_t> out(num_pixels * 4);
 
     float exposure_scale = std::exp2(exposure);
@@ -198,53 +201,55 @@ auto Image::to_rgba8(float exposure, float gamma) const
 
 // ── State queries ──
 
-auto Image::is_accumulation_mode() const -> bool { return !_weights.empty(); }
+auto Image::is_accumulation_mode() const -> bool {
+    return !m_weights.empty();
+}
 
 void Image::clear() {
-    std::fill(_pixels.begin(), _pixels.end(), 0.f);
-    std::fill(_weights.begin(), _weights.end(), 0.f);
-    _resolved.clear();
-    _resolved_version = 0;
-    _pixels_completed.store(0, std::memory_order_relaxed);
-    _version.fetch_add(1, std::memory_order_release);
-    _notify(0, 0, _width, _height);
+    std::fill(m_pixels.begin(), m_pixels.end(), 0.f);
+    std::fill(m_weights.begin(), m_weights.end(), 0.f);
+    m_resolved.clear();
+    m_resolved_version = 0;
+    m_pixels_completed.store(0, std::memory_order_relaxed);
+    m_version.fetch_add(1, std::memory_order_release);
+    notify(0, 0, m_width, m_height);
 }
 
 // ── Internal helpers ──
 
-auto Image::_pixel_index(size_t x, size_t y) const -> size_t {
-    assert(x < _width && y < _height);
-    return (y * _width + x) * 4;
+auto Image::pixel_index(size_t x, size_t y) const -> size_t {
+    if (x >= m_width || y >= m_height) { std::unreachable(); }
+    return (y * m_width + x) * 4;
 }
 
-void Image::_notify(size_t x, size_t y, size_t w, size_t h) {
-    if (_on_update) { _on_update(x, y, w, h); }
+void Image::notify(size_t x, size_t y, size_t w, size_t h) {
+    if (m_on_update) { m_on_update(x, y, w, h); }
 }
 
-void Image::_ensure_resolved() const {
-    uint64_t ver = _version.load(std::memory_order_acquire);
-    if (_resolved_version == ver && !_resolved.empty()) { return; }
+void Image::ensure_resolved() const {
+    uint64_t ver = m_version.load(std::memory_order_acquire);
+    if (m_resolved_version == ver && !m_resolved.empty()) { return; }
 
-    size_t num_pixels = _width * _height;
-    _resolved.resize(num_pixels * 4);
+    size_t num_pixels = m_width * m_height;
+    m_resolved.resize(num_pixels * 4);
 
     for (size_t i = 0; i < num_pixels; ++i) {
         size_t idx = i * 4;
-        float w = _weights[i];
+        float w = m_weights[i];
         if (w == 0.f) {
-            _resolved[idx + 0] = 0.f;
-            _resolved[idx + 1] = 0.f;
-            _resolved[idx + 2] = 0.f;
-            _resolved[idx + 3] = 0.f;
+            m_resolved[idx + 0] = 0.f;
+            m_resolved[idx + 1] = 0.f;
+            m_resolved[idx + 2] = 0.f;
+            m_resolved[idx + 3] = 0.f;
         } else {
             float inv_w = 1.f / w;
-            _resolved[idx + 0] = _pixels[idx + 0] * inv_w;
-            _resolved[idx + 1] = _pixels[idx + 1] * inv_w;
-            _resolved[idx + 2] = _pixels[idx + 2] * inv_w;
-            _resolved[idx + 3] = 1.f;
+            m_resolved[idx + 0] = m_pixels[idx + 0] * inv_w;
+            m_resolved[idx + 1] = m_pixels[idx + 1] * inv_w;
+            m_resolved[idx + 2] = m_pixels[idx + 2] * inv_w;
+            m_resolved[idx + 3] = 1.f;
         }
     }
-    _resolved_version = ver;
+    m_resolved_version = ver;
 }
 
 } // namespace art

--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -1,0 +1,250 @@
+#include "art/Image.hpp"
+
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+
+namespace art {
+
+Image::Image(size_t width, size_t height, PixelFormat format)
+  : _width(width), _height(height), _format(format),
+    _pixels(width * height * 4, 0.f) {}
+
+Image::Image(Image &&other) noexcept
+  : _width(other._width), _height(other._height), _format(other._format),
+    _pixels(std::move(other._pixels)), _weights(std::move(other._weights)),
+    _resolved(std::move(other._resolved)),
+    _resolved_version(other._resolved_version),
+    _pixels_completed(other._pixels_completed.load(std::memory_order_relaxed)),
+    _version(other._version.load(std::memory_order_relaxed)),
+    _on_update(std::move(other._on_update)) {
+    other._width = 0;
+    other._height = 0;
+}
+
+Image &Image::operator=(Image &&other) noexcept {
+    if (this != &other) {
+        _width = other._width;
+        _height = other._height;
+        _format = other._format;
+        _pixels = std::move(other._pixels);
+        _weights = std::move(other._weights);
+        _resolved = std::move(other._resolved);
+        _resolved_version = other._resolved_version;
+        _pixels_completed.store(
+            other._pixels_completed.load(std::memory_order_relaxed),
+            std::memory_order_relaxed);
+        _version.store(other._version.load(std::memory_order_relaxed),
+                       std::memory_order_relaxed);
+        _on_update = std::move(other._on_update);
+        other._width = 0;
+        other._height = 0;
+    }
+    return *this;
+}
+
+// ── Dimensions ──
+
+auto Image::width() const -> size_t { return _width; }
+auto Image::height() const -> size_t { return _height; }
+auto Image::format() const -> PixelFormat { return _format; }
+
+// ── Direct pixel access ──
+
+void Image::set_pixel(size_t x, size_t y, float r, float g, float b, float a) {
+    size_t idx = _pixel_index(x, y);
+    _pixels[idx + 0] = r;
+    _pixels[idx + 1] = g;
+    _pixels[idx + 2] = b;
+    _pixels[idx + 3] = a;
+    _version.fetch_add(1, std::memory_order_release);
+    _notify(x, y, 1, 1);
+}
+
+auto Image::pixel(size_t x, size_t y) const -> std::array<float, 4> {
+    size_t idx = _pixel_index(x, y);
+    return {
+        _pixels[idx + 0], _pixels[idx + 1], _pixels[idx + 2], _pixels[idx + 3]};
+}
+
+// ── Sample accumulation ──
+
+void Image::add_sample(size_t x,
+                       size_t y,
+                       float r,
+                       float g,
+                       float b,
+                       float weight) {
+    // Lazily allocate weight buffer on first use.
+    if (_weights.empty()) { _weights.resize(_width * _height, 0.f); }
+    size_t idx = _pixel_index(x, y);
+    size_t pidx = (y * _width + x);
+    _pixels[idx + 0] += r * weight;
+    _pixels[idx + 1] += g * weight;
+    _pixels[idx + 2] += b * weight;
+    _pixels[idx + 3] += weight; // alpha accumulates weight for now
+    _weights[pidx] += weight;
+    _version.fetch_add(1, std::memory_order_release);
+    _notify(x, y, 1, 1);
+}
+
+auto Image::resolved_pixel(size_t x, size_t y) const -> std::array<float, 4> {
+    size_t idx = _pixel_index(x, y);
+
+    if (_weights.empty()) {
+        // Direct mode — return as-is.
+        return {_pixels[idx + 0],
+                _pixels[idx + 1],
+                _pixels[idx + 2],
+                _pixels[idx + 3]};
+    }
+
+    // Accumulation mode — normalize by weight.
+    size_t pidx = (y * _width + x);
+    float w = _weights[pidx];
+    if (w == 0.f) { return {0.f, 0.f, 0.f, 0.f}; }
+    float inv_w = 1.f / w;
+    return {_pixels[idx + 0] * inv_w,
+            _pixels[idx + 1] * inv_w,
+            _pixels[idx + 2] * inv_w,
+            1.f};
+}
+
+// ── Bulk access ──
+
+void Image::set_scanline(size_t y, std::span<const float> rgba_row) {
+    assert(rgba_row.size() >= _width * 4);
+    size_t idx = _pixel_index(0, y);
+    std::copy_n(rgba_row.data(), _width * 4, _pixels.data() + idx);
+    _version.fetch_add(1, std::memory_order_release);
+    _notify(0, y, _width, 1);
+}
+
+void Image::set_tile(size_t x,
+                     size_t y,
+                     size_t w,
+                     size_t h,
+                     std::span<const float> rgba_data) {
+    assert(rgba_data.size() >= w * h * 4);
+    for (size_t row = 0; row < h; ++row) {
+        size_t dst_idx = _pixel_index(x, y + row);
+        size_t src_idx = row * w * 4;
+        std::copy_n(
+            rgba_data.data() + src_idx, w * 4, _pixels.data() + dst_idx);
+    }
+    _version.fetch_add(1, std::memory_order_release);
+    _notify(x, y, w, h);
+}
+
+auto Image::pixels() const -> std::span<const float> {
+    if (_weights.empty()) { return _pixels; }
+    _ensure_resolved();
+    return _resolved;
+}
+
+auto Image::raw_pixels() const -> std::span<const float> { return _pixels; }
+
+// ── Progress tracking ──
+
+void Image::increment_progress(size_t count) {
+    _pixels_completed.fetch_add(count, std::memory_order_relaxed);
+}
+
+auto Image::pixels_completed() const -> size_t {
+    return _pixels_completed.load(std::memory_order_relaxed);
+}
+
+auto Image::total_pixels() const -> size_t { return _width * _height; }
+
+auto Image::progress_fraction() const -> float {
+    size_t total = total_pixels();
+    if (total == 0) return 0.f;
+    return static_cast<float>(pixels_completed()) / static_cast<float>(total);
+}
+
+// ── Dirty tracking + notification ──
+
+auto Image::version() const -> uint64_t {
+    return _version.load(std::memory_order_acquire);
+}
+
+void Image::set_on_update(UpdateCallback cb) { _on_update = std::move(cb); }
+
+// ── Conversion ──
+
+auto Image::to_rgba8(float exposure, float gamma) const
+    -> std::vector<uint8_t> {
+    auto src = pixels(); // resolved if in accumulation mode
+    size_t num_pixels = _width * _height;
+    std::vector<uint8_t> out(num_pixels * 4);
+
+    float exposure_scale = std::exp2(exposure);
+    float inv_gamma = 1.f / gamma;
+
+    for (size_t i = 0; i < num_pixels; ++i) {
+        size_t si = i * 4;
+        for (size_t c = 0; c < 3; ++c) {
+            float v = src[si + c] * exposure_scale;
+            v = std::pow(std::max(v, 0.f), inv_gamma);
+            v = std::clamp(v, 0.f, 1.f);
+            out[si + c] = static_cast<uint8_t>(v * 255.f + 0.5f);
+        }
+        // Alpha: linear, no tone mapping
+        float a = std::clamp(src[si + 3], 0.f, 1.f);
+        out[si + 3] = static_cast<uint8_t>(a * 255.f + 0.5f);
+    }
+    return out;
+}
+
+// ── State queries ──
+
+auto Image::is_accumulation_mode() const -> bool { return !_weights.empty(); }
+
+void Image::clear() {
+    std::fill(_pixels.begin(), _pixels.end(), 0.f);
+    std::fill(_weights.begin(), _weights.end(), 0.f);
+    _resolved.clear();
+    _resolved_version = 0;
+    _pixels_completed.store(0, std::memory_order_relaxed);
+    _version.fetch_add(1, std::memory_order_release);
+    _notify(0, 0, _width, _height);
+}
+
+// ── Internal helpers ──
+
+auto Image::_pixel_index(size_t x, size_t y) const -> size_t {
+    assert(x < _width && y < _height);
+    return (y * _width + x) * 4;
+}
+
+void Image::_notify(size_t x, size_t y, size_t w, size_t h) {
+    if (_on_update) { _on_update(x, y, w, h); }
+}
+
+void Image::_ensure_resolved() const {
+    uint64_t ver = _version.load(std::memory_order_acquire);
+    if (_resolved_version == ver && !_resolved.empty()) { return; }
+
+    size_t num_pixels = _width * _height;
+    _resolved.resize(num_pixels * 4);
+
+    for (size_t i = 0; i < num_pixels; ++i) {
+        size_t idx = i * 4;
+        float w = _weights[i];
+        if (w == 0.f) {
+            _resolved[idx + 0] = 0.f;
+            _resolved[idx + 1] = 0.f;
+            _resolved[idx + 2] = 0.f;
+            _resolved[idx + 3] = 0.f;
+        } else {
+            float inv_w = 1.f / w;
+            _resolved[idx + 0] = _pixels[idx + 0] * inv_w;
+            _resolved[idx + 1] = _pixels[idx + 1] * inv_w;
+            _resolved[idx + 2] = _pixels[idx + 2] * inv_w;
+            _resolved[idx + 3] = 1.f;
+        }
+    }
+    _resolved_version = ver;
+}
+
+} // namespace art

--- a/src/io/exr.cpp
+++ b/src/io/exr.cpp
@@ -1,0 +1,101 @@
+#include "art/io/image_io.hpp"
+
+#ifdef ART_HAS_EXR
+
+#include <tinyexr.h>
+
+#include <cstring>
+
+namespace art::io {
+
+auto has_exr_support() -> bool { return true; }
+
+namespace exr {
+
+    auto load(const std::filesystem::path &path)
+        -> std::expected<Image, std::string> {
+        float *rgba = nullptr;
+        int width = 0, height = 0;
+        const char *err = nullptr;
+
+        int ret = LoadEXR(&rgba, &width, &height, path.string().c_str(), &err);
+        if (ret != TINYEXR_SUCCESS) {
+            std::string msg = err ? std::string(err) : "Unknown EXR error";
+            if (err) FreeEXRErrorMessage(err);
+            return std::unexpected("Failed to load EXR: " + msg);
+        }
+
+        Image img(static_cast<size_t>(width), static_cast<size_t>(height));
+        // tinyexr LoadEXR returns RGBA float interleaved
+        for (int y = 0; y < height; ++y) {
+            for (int x = 0; x < width; ++x) {
+                size_t i = static_cast<size_t>(y * width + x) * 4;
+                img.set_pixel(static_cast<size_t>(x),
+                              static_cast<size_t>(y),
+                              rgba[i + 0],
+                              rgba[i + 1],
+                              rgba[i + 2],
+                              rgba[i + 3]);
+            }
+        }
+        free(rgba);
+
+        return img;
+    }
+
+    auto save(const std::filesystem::path &path, const Image &image)
+        -> std::expected<void, std::string> {
+        if (image.width() == 0 || image.height() == 0) {
+            return std::unexpected("Cannot save empty image");
+        }
+
+        auto pixels = image.pixels();
+        int width = static_cast<int>(image.width());
+        int height = static_cast<int>(image.height());
+
+        const char *err = nullptr;
+        int ret = SaveEXR(pixels.data(),
+                          width,
+                          height,
+                          /*num_channels=*/4,
+                          /*save_as_fp16=*/1,
+                          path.string().c_str(),
+                          &err);
+        if (ret != TINYEXR_SUCCESS) {
+            std::string msg = err ? std::string(err) : "Unknown EXR error";
+            if (err) FreeEXRErrorMessage(err);
+            return std::unexpected("Failed to save EXR: " + msg);
+        }
+
+        return {};
+    }
+
+} // namespace exr
+
+} // namespace art::io
+
+#else // !ART_HAS_EXR
+
+namespace art::io {
+
+auto has_exr_support() -> bool { return false; }
+
+namespace exr {
+
+    auto load(const std::filesystem::path &)
+        -> std::expected<Image, std::string> {
+        return std::unexpected(
+            "EXR support not compiled; rebuild with -Dexr=true");
+    }
+
+    auto save(const std::filesystem::path &, const Image &)
+        -> std::expected<void, std::string> {
+        return std::unexpected(
+            "EXR support not compiled; rebuild with -Dexr=true");
+    }
+
+} // namespace exr
+
+} // namespace art::io
+
+#endif // ART_HAS_EXR

--- a/src/io/image_io.cpp
+++ b/src/io/image_io.cpp
@@ -1,0 +1,72 @@
+#include "art/io/image_io.hpp"
+
+#include <algorithm>
+
+namespace art::io {
+
+namespace {
+
+    auto deduce_format(const std::filesystem::path &path)
+        -> std::expected<ImageFormat, std::string> {
+        auto ext = path.extension().string();
+        std::transform(ext.begin(),
+                       ext.end(),
+                       ext.begin(),
+                       [](unsigned char c) { return std::tolower(c); });
+
+        if (ext == ".exr") return ImageFormat::EXR;
+        if (ext == ".png") return ImageFormat::PNG;
+        if (ext == ".ppm") return ImageFormat::PPM;
+        return std::unexpected("Unknown image format for extension '" + ext
+                               + "'");
+    }
+
+} // namespace
+
+auto load(const std::filesystem::path &path, ImageFormat format)
+    -> std::expected<Image, std::string> {
+    if (format == ImageFormat::Auto) {
+        auto fmt = deduce_format(path);
+        if (!fmt) return std::unexpected(fmt.error());
+        format = *fmt;
+    }
+
+    switch (format) {
+    case ImageFormat::EXR:
+        return exr::load(path);
+    case ImageFormat::PNG:
+        return png::load(path);
+    case ImageFormat::PPM:
+        return ppm::load(path);
+    case ImageFormat::Auto:
+        break; // unreachable
+    }
+    return std::unexpected("Unknown image format");
+}
+
+auto save(const std::filesystem::path &path,
+          const Image &image,
+          ImageFormat format,
+          const SaveOptions &opts) -> std::expected<void, std::string> {
+    if (format == ImageFormat::Auto) {
+        auto fmt = deduce_format(path);
+        if (!fmt) return std::unexpected(fmt.error());
+        format = *fmt;
+    }
+
+    switch (format) {
+    case ImageFormat::EXR:
+        return exr::save(path, image);
+    case ImageFormat::PNG:
+        return png::save(path, image, opts);
+    case ImageFormat::PPM:
+        return ppm::save(path, image, opts);
+    case ImageFormat::Auto:
+        break; // unreachable
+    }
+    return std::unexpected("Unknown image format");
+}
+
+auto has_ppm_support() -> bool { return true; }
+
+} // namespace art::io

--- a/src/io/png.cpp
+++ b/src/io/png.cpp
@@ -1,0 +1,93 @@
+#include "art/io/image_io.hpp"
+
+#ifdef ART_HAS_PNG
+
+#define STB_IMAGE_IMPLEMENTATION
+#include <stb_image.h>
+
+#define STB_IMAGE_WRITE_IMPLEMENTATION
+#include <stb_image_write.h>
+
+namespace art::io {
+
+auto has_png_support() -> bool { return true; }
+
+namespace png {
+
+    auto load(const std::filesystem::path &path)
+        -> std::expected<Image, std::string> {
+        int width = 0, height = 0, channels = 0;
+        unsigned char *data =
+            stbi_load(path.string().c_str(), &width, &height, &channels, 4);
+        if (!data) {
+            return std::unexpected("Failed to load PNG: "
+                                   + std::string(stbi_failure_reason()));
+        }
+
+        Image img(static_cast<size_t>(width), static_cast<size_t>(height));
+        // Convert RGBA8 -> RGBAF32 (assuming sRGB input)
+        for (int y = 0; y < height; ++y) {
+            for (int x = 0; x < width; ++x) {
+                size_t i = static_cast<size_t>(y * width + x) * 4;
+                float r = static_cast<float>(data[i + 0]) / 255.f;
+                float g = static_cast<float>(data[i + 1]) / 255.f;
+                float b = static_cast<float>(data[i + 2]) / 255.f;
+                float a = static_cast<float>(data[i + 3]) / 255.f;
+                img.set_pixel(
+                    static_cast<size_t>(x), static_cast<size_t>(y), r, g, b, a);
+            }
+        }
+        stbi_image_free(data);
+
+        return img;
+    }
+
+    auto save(const std::filesystem::path &path,
+              const Image &image,
+              const SaveOptions &opts) -> std::expected<void, std::string> {
+        if (image.width() == 0 || image.height() == 0) {
+            return std::unexpected("Cannot save empty image");
+        }
+
+        auto rgba8 = image.to_rgba8(opts.exposure, opts.gamma);
+        int width = static_cast<int>(image.width());
+        int height = static_cast<int>(image.height());
+
+        int ret = stbi_write_png(
+            path.string().c_str(), width, height, 4, rgba8.data(), width * 4);
+        if (ret == 0) {
+            return std::unexpected("Failed to write PNG: " + path.string());
+        }
+
+        return {};
+    }
+
+} // namespace png
+
+} // namespace art::io
+
+#else // !ART_HAS_PNG
+
+namespace art::io {
+
+auto has_png_support() -> bool { return false; }
+
+namespace png {
+
+    auto load(const std::filesystem::path &)
+        -> std::expected<Image, std::string> {
+        return std::unexpected(
+            "PNG support not compiled; rebuild with -Dpng=true");
+    }
+
+    auto save(const std::filesystem::path &, const Image &, const SaveOptions &)
+        -> std::expected<void, std::string> {
+        return std::unexpected(
+            "PNG support not compiled; rebuild with -Dpng=true");
+    }
+
+} // namespace png
+
+} // namespace art::io
+
+#endif // ART_HAS_PNG

--- a/src/io/ppm.cpp
+++ b/src/io/ppm.cpp
@@ -1,0 +1,111 @@
+#include "art/io/image_io.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <cstdint>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+namespace art::io::ppm {
+
+auto load(const std::filesystem::path &path)
+    -> std::expected<Image, std::string> {
+    std::ifstream file(path, std::ios::binary);
+    if (!file) { return std::unexpected("Cannot open file: " + path.string()); }
+
+    // Read magic number
+    std::string magic;
+    file >> magic;
+    if (magic != "P6") {
+        return std::unexpected("Not a binary PPM file (expected P6, got "
+                               + magic + ")");
+    }
+
+    // Skip whitespace and comments
+    auto skip_comments = [&file]() {
+        file >> std::ws;
+        while (file.peek() == '#') {
+            file.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+            file >> std::ws;
+        }
+    };
+
+    skip_comments();
+
+    size_t width, height;
+    file >> width;
+    skip_comments();
+    file >> height;
+    skip_comments();
+
+    int max_val;
+    file >> max_val;
+
+    // Consume the single whitespace character after maxval
+    file.get();
+
+    if (!file || width == 0 || height == 0) {
+        return std::unexpected("Invalid PPM header in " + path.string());
+    }
+
+    if (max_val != 255) {
+        return std::unexpected("Only 8-bit PPM supported (maxval="
+                               + std::to_string(max_val) + ")");
+    }
+
+    // Read RGB pixels
+    std::vector<uint8_t> rgb(width * height * 3);
+    file.read(reinterpret_cast<char *>(rgb.data()),
+              static_cast<std::streamsize>(rgb.size()));
+    if (!file) {
+        return std::unexpected("Truncated pixel data in " + path.string());
+    }
+
+    // Convert RGB8 -> RGBAF32
+    Image img(width, height);
+    for (size_t i = 0; i < width * height; ++i) {
+        float r = static_cast<float>(rgb[i * 3 + 0]) / 255.f;
+        float g = static_cast<float>(rgb[i * 3 + 1]) / 255.f;
+        float b = static_cast<float>(rgb[i * 3 + 2]) / 255.f;
+        size_t x = i % width;
+        size_t y = i / width;
+        img.set_pixel(x, y, r, g, b, 1.f);
+    }
+
+    return img;
+}
+
+auto save(const std::filesystem::path &path,
+          const Image &image,
+          const SaveOptions &opts) -> std::expected<void, std::string> {
+    if (image.width() == 0 || image.height() == 0) {
+        return std::unexpected("Cannot save empty image");
+    }
+
+    std::ofstream file(path, std::ios::binary);
+    if (!file) {
+        return std::unexpected("Cannot open file for writing: "
+                               + path.string());
+    }
+
+    auto rgba8 = image.to_rgba8(opts.exposure, opts.gamma);
+
+    // Write PPM P6 header
+    file << "P6\n"
+         << image.width() << " " << image.height() << "\n"
+         << "255\n";
+
+    // Write RGB pixels (strip alpha)
+    for (size_t i = 0; i < image.width() * image.height(); ++i) {
+        file.put(static_cast<char>(rgba8[i * 4 + 0]));
+        file.put(static_cast<char>(rgba8[i * 4 + 1]));
+        file.put(static_cast<char>(rgba8[i * 4 + 2]));
+    }
+
+    if (!file) { return std::unexpected("Write error to " + path.string()); }
+
+    return {};
+}
+
+} // namespace art::io::ppm

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,6 +5,7 @@
 #include "art/Camera.hpp"
 #include "art/geometry/Box.hpp"
 #include "art/geometry/Sphere.hpp"
+#include "art/io/image_io.hpp"
 #include "art/objects/InternalSceneNode.hpp"
 #include "art/objects/Object.hpp"
 
@@ -62,8 +63,12 @@ void both() {
     scene->update_bounding_box();
 
     Image img = cam.render(100, 100, *scene);
+    auto result = art::io::save("both.ppm", img);
+    if (!result) {
+        std::cerr << "Failed to save: " << result.error() << std::endl;
+    }
 }
-int main(int argc, char* argv[]) {
+int main([[maybe_unused]] int argc, [[maybe_unused]] char *argv[]) {
     sphere();
     cube();
     both();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,7 +11,7 @@
 
 void sphere() {
     using namespace art;
-    Camera cam(Camera::lookAt(/*position=*/Point(0, 0, 5),
+    Camera cam(Camera::look_at(/*position=*/Point(0, 0, 5),
                               /*looking_at=*/Point(0, 0, 0),
                               /*up=*/Point(0, 1, 0)));
 
@@ -23,7 +23,7 @@ void sphere() {
 
 void cube() {
     using namespace art;
-    Camera cam(Camera::lookAt(/*position=*/Point(0, 0, 5),
+    Camera cam(Camera::look_at(/*position=*/Point(0, 0, 5),
                               /*looking_at=*/Point(0, 0, 0),
                               /*up=*/Point(0, 1, 0)));
 
@@ -39,7 +39,7 @@ void cube() {
 
 void both() {
     using namespace art;
-    Camera cam(Camera::lookAt(/*position=*/Point(0, 0, 5),
+    Camera cam(Camera::look_at(/*position=*/Point(0, 0, 5),
                               /*looking_at=*/Point(0, 0, 0),
                               /*up=*/Point(0, 1, 0)));
 

--- a/subprojects/mdspan.wrap
+++ b/subprojects/mdspan.wrap
@@ -1,0 +1,2 @@
+[wrap-redirect]
+filename = zipper/subprojects/mdspan.wrap

--- a/subprojects/packagefiles/stb/meson.build
+++ b/subprojects/packagefiles/stb/meson.build
@@ -1,0 +1,11 @@
+project('stb', 'c',
+  version : '0.0.1',
+  default_options : ['warning_level=0'])
+
+# stb is a collection of single-file header-only libraries.
+# We expose include directories so consumers can #include <stb_image.h> etc.
+
+stb_inc = include_directories('.')
+
+stb_dep = declare_dependency(
+  include_directories: stb_inc)

--- a/subprojects/packagefiles/tinyexr/meson.build
+++ b/subprojects/packagefiles/tinyexr/meson.build
@@ -1,0 +1,17 @@
+project('tinyexr', 'c', 'cpp',
+  version : '1.0.9',
+  default_options : ['warning_level=0', 'cpp_std=c++17', 'c_std=c11'])
+
+# tinyexr is a single-header library that depends on miniz for
+# zlib compression. Both are compiled here into a static library.
+
+tinyexr_inc = include_directories('.', 'deps/miniz')
+
+tinyexr_lib = static_library('tinyexr',
+  'tinyexr_impl.cpp',
+  'deps/miniz/miniz.c',
+  include_directories: tinyexr_inc)
+
+tinyexr_dep = declare_dependency(
+  include_directories: tinyexr_inc,
+  link_with: tinyexr_lib)

--- a/subprojects/packagefiles/tinyexr/tinyexr_impl.cpp
+++ b/subprojects/packagefiles/tinyexr/tinyexr_impl.cpp
@@ -1,0 +1,2 @@
+#define TINYEXR_IMPLEMENTATION
+#include "tinyexr.h"

--- a/subprojects/stb.wrap
+++ b/subprojects/stb.wrap
@@ -1,0 +1,9 @@
+[wrap-file]
+directory = stb-f0569113c93ad095470c54bf34a17b36646bbbb5
+source_url = https://github.com/nothings/stb/archive/f0569113c93ad095470c54bf34a17b36646bbbb5.tar.gz
+source_filename = stb-f0569113c93ad095470c54bf34a17b36646bbbb5.tar.gz
+source_hash = 4d05c96640ae3a8cbdafdad8d344b50ce610802f78aee80154acdb8e266282e0
+patch_directory = stb
+
+[provide]
+stb = stb_dep

--- a/subprojects/tinyexr.wrap
+++ b/subprojects/tinyexr.wrap
@@ -1,0 +1,9 @@
+[wrap-file]
+directory = tinyexr-1.0.9
+source_url = https://github.com/syoyo/tinyexr/archive/refs/tags/v1.0.9.tar.gz
+source_filename = tinyexr-1.0.9.tar.gz
+source_hash = f9e05127c3db23f9c4269c9a922ed0d3d911486efd884883e1f01b0ee19de91e
+patch_directory = tinyexr
+
+[provide]
+tinyexr = tinyexr_dep

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -3,6 +3,6 @@ catch2_with_main_dep = dependency('catch2-with-main', default_options: ['tests=f
 art_test_dep = declare_dependency(
   dependencies: [art_dep, catch2_with_main_dep])
 
-sources = ['test_point.cpp', 'test_rational.cpp']
+sources = ['test_point.cpp', 'test_rational.cpp', 'test_image.cpp', 'test_image_io.cpp']
 test_art = executable('test_art', sources, dependencies: [art_test_dep])
 test('art', test_art)

--- a/tests/test_image.cpp
+++ b/tests/test_image.cpp
@@ -1,0 +1,358 @@
+#include <catch2/catch_all.hpp>
+
+#include "art/Image.hpp"
+
+using namespace art;
+
+TEST_CASE("image_construction", "[image]") {
+    SECTION("default construction") {
+        Image img;
+        CHECK(img.width() == 0);
+        CHECK(img.height() == 0);
+        CHECK(img.total_pixels() == 0);
+        CHECK(img.progress_fraction() == 0.f);
+    }
+
+    SECTION("sized construction") {
+        Image img(100, 50);
+        CHECK(img.width() == 100);
+        CHECK(img.height() == 50);
+        CHECK(img.format() == Image::PixelFormat::RGBAF32);
+        CHECK(img.total_pixels() == 5000);
+        CHECK(img.pixels_completed() == 0);
+    }
+
+    SECTION("pixels initialized to zero") {
+        Image img(4, 4);
+        auto px = img.pixel(0, 0);
+        CHECK(px[0] == 0.f);
+        CHECK(px[1] == 0.f);
+        CHECK(px[2] == 0.f);
+        CHECK(px[3] == 0.f);
+
+        auto px2 = img.pixel(3, 3);
+        CHECK(px2[0] == 0.f);
+    }
+}
+
+TEST_CASE("image_set_pixel", "[image]") {
+    Image img(10, 10);
+
+    img.set_pixel(5, 3, 1.f, 0.5f, 0.25f, 0.75f);
+
+    auto px = img.pixel(5, 3);
+    CHECK(px[0] == 1.f);
+    CHECK(px[1] == 0.5f);
+    CHECK(px[2] == 0.25f);
+    CHECK(px[3] == 0.75f);
+
+    // Other pixels unaffected
+    auto other = img.pixel(0, 0);
+    CHECK(other[0] == 0.f);
+}
+
+TEST_CASE("image_set_pixel_default_alpha", "[image]") {
+    Image img(4, 4);
+    img.set_pixel(0, 0, 0.5f, 0.5f, 0.5f);
+
+    auto px = img.pixel(0, 0);
+    CHECK(px[3] == 1.f);
+}
+
+TEST_CASE("image_resolved_pixel_direct_mode", "[image]") {
+    Image img(4, 4);
+    img.set_pixel(2, 1, 0.8f, 0.6f, 0.4f, 1.f);
+
+    auto px = img.resolved_pixel(2, 1);
+    CHECK(px[0] == 0.8f);
+    CHECK(px[1] == 0.6f);
+    CHECK(px[2] == 0.4f);
+    CHECK(px[3] == 1.f);
+}
+
+TEST_CASE("image_sample_accumulation", "[image]") {
+    Image img(4, 4);
+
+    CHECK_FALSE(img.is_accumulation_mode());
+
+    // Add two samples with equal weight
+    img.add_sample(1, 1, 1.f, 0.f, 0.f, 1.f); // red, weight 1
+    img.add_sample(1, 1, 0.f, 0.f, 1.f, 1.f); // blue, weight 1
+
+    CHECK(img.is_accumulation_mode());
+
+    auto px = img.resolved_pixel(1, 1);
+    CHECK(px[0] == Catch::Approx(0.5f)); // (1*1 + 0*1) / 2
+    CHECK(px[1] == Catch::Approx(0.f));
+    CHECK(px[2] == Catch::Approx(0.5f)); // (0*1 + 1*1) / 2
+    CHECK(px[3] == Catch::Approx(1.f));
+}
+
+TEST_CASE("image_sample_accumulation_weighted", "[image]") {
+    Image img(4, 4);
+
+    // Add samples with different weights
+    img.add_sample(0, 0, 1.f, 0.f, 0.f, 3.f); // red, weight 3
+    img.add_sample(0, 0, 0.f, 1.f, 0.f, 1.f); // green, weight 1
+
+    auto px = img.resolved_pixel(0, 0);
+    // total weight = 4
+    CHECK(px[0] == Catch::Approx(0.75f)); // (1*3) / 4
+    CHECK(px[1] == Catch::Approx(0.25f)); // (1*1) / 4
+    CHECK(px[2] == Catch::Approx(0.f));
+}
+
+TEST_CASE("image_sample_accumulation_zero_weight", "[image]") {
+    Image img(4, 4);
+    img.add_sample(0, 0, 1.f, 1.f, 1.f, 0.f);
+
+    auto px = img.resolved_pixel(0, 0);
+    CHECK(px[0] == 0.f);
+    CHECK(px[1] == 0.f);
+    CHECK(px[2] == 0.f);
+    CHECK(px[3] == 0.f);
+}
+
+TEST_CASE("image_set_scanline", "[image]") {
+    Image img(3, 2);
+
+    // Row 0: red, green, blue
+    std::vector<float> row = {
+        1.f,
+        0.f,
+        0.f,
+        1.f, // red
+        0.f,
+        1.f,
+        0.f,
+        1.f, // green
+        0.f,
+        0.f,
+        1.f,
+        1.f, // blue
+    };
+    img.set_scanline(0, row);
+
+    auto r = img.pixel(0, 0);
+    CHECK(r[0] == 1.f);
+    CHECK(r[1] == 0.f);
+
+    auto g = img.pixel(1, 0);
+    CHECK(g[1] == 1.f);
+
+    auto b = img.pixel(2, 0);
+    CHECK(b[2] == 1.f);
+
+    // Row 1 should still be zero
+    auto zero = img.pixel(0, 1);
+    CHECK(zero[0] == 0.f);
+}
+
+TEST_CASE("image_set_tile", "[image]") {
+    Image img(8, 8);
+
+    // Set a 2x2 tile at position (3, 4)
+    std::vector<float> tile = {
+        0.1f,
+        0.2f,
+        0.3f,
+        1.f, // (3,4)
+        0.4f,
+        0.5f,
+        0.6f,
+        1.f, // (4,4)
+        0.7f,
+        0.8f,
+        0.9f,
+        1.f, // (3,5)
+        1.0f,
+        0.9f,
+        0.8f,
+        1.f, // (4,5)
+    };
+    img.set_tile(3, 4, 2, 2, tile);
+
+    auto p00 = img.pixel(3, 4);
+    CHECK(p00[0] == Catch::Approx(0.1f));
+    CHECK(p00[1] == Catch::Approx(0.2f));
+
+    auto p10 = img.pixel(4, 4);
+    CHECK(p10[0] == Catch::Approx(0.4f));
+
+    auto p01 = img.pixel(3, 5);
+    CHECK(p01[0] == Catch::Approx(0.7f));
+
+    auto p11 = img.pixel(4, 5);
+    CHECK(p11[0] == Catch::Approx(1.0f));
+
+    // Adjacent pixel unchanged
+    auto adj = img.pixel(2, 4);
+    CHECK(adj[0] == 0.f);
+}
+
+TEST_CASE("image_pixels_span_direct_mode", "[image]") {
+    Image img(2, 2);
+    img.set_pixel(0, 0, 1.f, 0.f, 0.f, 1.f);
+    img.set_pixel(1, 0, 0.f, 1.f, 0.f, 1.f);
+
+    auto span = img.pixels();
+    CHECK(span.size() == 16); // 2*2*4
+    CHECK(span[0] == 1.f); // (0,0).r
+    CHECK(span[5] == 1.f); // (1,0).g
+}
+
+TEST_CASE("image_pixels_span_accumulation_mode", "[image]") {
+    Image img(2, 1);
+    img.add_sample(0, 0, 2.f, 0.f, 0.f, 2.f);
+    img.add_sample(1, 0, 0.f, 4.f, 0.f, 4.f);
+
+    auto span = img.pixels();
+    CHECK(span.size() == 8); // 2*1*4
+    // pixel (0,0): accumulated r = 2*2 = 4, weight = 2, resolved = 4/2 = 2
+    CHECK(span[0] == Catch::Approx(2.f));
+    // pixel (1,0): accumulated g = 4*4 = 16, weight = 4, resolved = 16/4 = 4
+    CHECK(span[5] == Catch::Approx(4.f));
+}
+
+TEST_CASE("image_raw_pixels", "[image]") {
+    Image img(2, 1);
+    img.add_sample(0, 0, 2.f, 0.f, 0.f, 2.f);
+
+    auto raw = img.raw_pixels();
+    CHECK(raw[0] == Catch::Approx(4.f)); // 2 * 2 (accumulated)
+}
+
+TEST_CASE("image_progress_tracking", "[image]") {
+    Image img(10, 10);
+
+    CHECK(img.pixels_completed() == 0);
+    CHECK(img.progress_fraction() == Catch::Approx(0.f));
+
+    img.increment_progress(50);
+    CHECK(img.pixels_completed() == 50);
+    CHECK(img.progress_fraction() == Catch::Approx(0.5f));
+
+    img.increment_progress(50);
+    CHECK(img.pixels_completed() == 100);
+    CHECK(img.progress_fraction() == Catch::Approx(1.f));
+}
+
+TEST_CASE("image_version_tracking", "[image]") {
+    Image img(4, 4);
+
+    uint64_t v0 = img.version();
+    img.set_pixel(0, 0, 1.f, 0.f, 0.f, 1.f);
+    uint64_t v1 = img.version();
+    CHECK(v1 > v0);
+
+    img.set_pixel(1, 1, 0.f, 1.f, 0.f, 1.f);
+    uint64_t v2 = img.version();
+    CHECK(v2 > v1);
+}
+
+TEST_CASE("image_update_callback", "[image]") {
+    Image img(8, 8);
+
+    size_t cb_count = 0;
+    size_t last_x = 0, last_y = 0, last_w = 0, last_h = 0;
+
+    img.set_on_update([&](size_t x, size_t y, size_t w, size_t h) {
+        cb_count++;
+        last_x = x;
+        last_y = y;
+        last_w = w;
+        last_h = h;
+    });
+
+    img.set_pixel(3, 5, 1.f, 0.f, 0.f);
+    CHECK(cb_count == 1);
+    CHECK(last_x == 3);
+    CHECK(last_y == 5);
+    CHECK(last_w == 1);
+    CHECK(last_h == 1);
+
+    std::vector<float> row(8 * 4, 0.5f);
+    img.set_scanline(2, row);
+    CHECK(cb_count == 2);
+    CHECK(last_x == 0);
+    CHECK(last_y == 2);
+    CHECK(last_w == 8);
+    CHECK(last_h == 1);
+
+    std::vector<float> tile(2 * 3 * 4, 0.5f);
+    img.set_tile(1, 4, 2, 3, tile);
+    CHECK(cb_count == 3);
+    CHECK(last_x == 1);
+    CHECK(last_y == 4);
+    CHECK(last_w == 2);
+    CHECK(last_h == 3);
+}
+
+TEST_CASE("image_to_rgba8", "[image]") {
+    Image img(2, 1);
+
+    // Set known pixel values
+    img.set_pixel(0, 0, 1.f, 0.f, 0.f, 1.f); // pure red
+    img.set_pixel(1, 0, 0.f, 0.f, 0.f, 0.f); // black, transparent
+
+    // Default exposure=0, gamma=2.2
+    auto bytes = img.to_rgba8();
+    CHECK(bytes.size() == 8); // 2*1*4
+
+    // Red pixel: pow(1.0 * 1.0, 1/2.2) = 1.0 -> 255
+    CHECK(bytes[0] == 255);
+    CHECK(bytes[1] == 0);
+    CHECK(bytes[2] == 0);
+    CHECK(bytes[3] == 255);
+
+    // Black pixel
+    CHECK(bytes[4] == 0);
+    CHECK(bytes[5] == 0);
+    CHECK(bytes[6] == 0);
+    CHECK(bytes[7] == 0);
+}
+
+TEST_CASE("image_to_rgba8_exposure", "[image]") {
+    Image img(1, 1);
+    img.set_pixel(0, 0, 0.5f, 0.5f, 0.5f, 1.f);
+
+    // +1 EV doubles the value: 0.5 * 2 = 1.0
+    auto bytes = img.to_rgba8(1.f, 1.f); // gamma=1 for simple math
+    CHECK(bytes[0] == 255);
+    CHECK(bytes[1] == 255);
+    CHECK(bytes[2] == 255);
+}
+
+TEST_CASE("image_clear", "[image]") {
+    Image img(4, 4);
+
+    img.set_pixel(2, 2, 1.f, 1.f, 1.f, 1.f);
+    img.increment_progress(5);
+
+    uint64_t v_before = img.version();
+    img.clear();
+
+    auto px = img.pixel(2, 2);
+    CHECK(px[0] == 0.f);
+    CHECK(px[1] == 0.f);
+    CHECK(px[2] == 0.f);
+    CHECK(px[3] == 0.f);
+    CHECK(img.pixels_completed() == 0);
+    CHECK(img.version() > v_before);
+}
+
+TEST_CASE("image_clear_accumulation_mode", "[image]") {
+    Image img(4, 4);
+
+    img.add_sample(0, 0, 1.f, 0.f, 0.f, 1.f);
+    CHECK(img.is_accumulation_mode());
+
+    img.clear();
+    // Weight buffer still allocated, so still in accumulation mode,
+    // but values should be zero
+    auto px = img.resolved_pixel(0, 0);
+    CHECK(px[0] == 0.f);
+    CHECK(px[1] == 0.f);
+    CHECK(px[2] == 0.f);
+    CHECK(px[3] == 0.f);
+}

--- a/tests/test_image_io.cpp
+++ b/tests/test_image_io.cpp
@@ -1,0 +1,213 @@
+#include <catch2/catch_all.hpp>
+
+#include <filesystem>
+#include <fstream>
+
+#include "art/io/image_io.hpp"
+
+using namespace art;
+using namespace art::io;
+
+TEST_CASE("ppm_save_load_roundtrip", "[io][ppm]") {
+    Image img(4, 3);
+
+    // Set some known pixels
+    img.set_pixel(0, 0, 1.f, 0.f, 0.f, 1.f); // red
+    img.set_pixel(1, 0, 0.f, 1.f, 0.f, 1.f); // green
+    img.set_pixel(2, 0, 0.f, 0.f, 1.f, 1.f); // blue
+    img.set_pixel(3, 0, 1.f, 1.f, 1.f, 1.f); // white
+    img.set_pixel(0, 1, 0.5f, 0.5f, 0.5f, 1.f); // gray
+    img.set_pixel(0, 2, 0.f, 0.f, 0.f, 1.f); // black
+
+    auto tmp = std::filesystem::temp_directory_path() / "test_art.ppm";
+
+    // Save with gamma=1 and exposure=0 for predictable roundtrip
+    SaveOptions opts{.exposure = 0.f, .gamma = 1.f};
+    auto save_result = ppm::save(tmp, img, opts);
+    REQUIRE(save_result.has_value());
+
+    // Load back
+    auto load_result = ppm::load(tmp);
+    REQUIRE(load_result.has_value());
+
+    auto &loaded = *load_result;
+    CHECK(loaded.width() == 4);
+    CHECK(loaded.height() == 3);
+
+    // Red pixel: 1.0 -> 255 -> 1.0 (within 8-bit quantization)
+    auto red = loaded.pixel(0, 0);
+    CHECK(red[0] == Catch::Approx(1.f).margin(1.f / 255.f));
+    CHECK(red[1] == Catch::Approx(0.f).margin(1.f / 255.f));
+    CHECK(red[2] == Catch::Approx(0.f).margin(1.f / 255.f));
+
+    // Green pixel
+    auto green = loaded.pixel(1, 0);
+    CHECK(green[0] == Catch::Approx(0.f).margin(1.f / 255.f));
+    CHECK(green[1] == Catch::Approx(1.f).margin(1.f / 255.f));
+
+    // Gray pixel
+    auto gray = loaded.pixel(0, 1);
+    CHECK(gray[0] == Catch::Approx(0.5f).margin(1.f / 255.f));
+    CHECK(gray[1] == Catch::Approx(0.5f).margin(1.f / 255.f));
+    CHECK(gray[2] == Catch::Approx(0.5f).margin(1.f / 255.f));
+
+    // Black pixel
+    auto black = loaded.pixel(0, 2);
+    CHECK(black[0] == Catch::Approx(0.f).margin(1.f / 255.f));
+
+    std::filesystem::remove(tmp);
+}
+
+TEST_CASE("ppm_load_nonexistent", "[io][ppm]") {
+    auto result = ppm::load("/nonexistent/path.ppm");
+    CHECK_FALSE(result.has_value());
+}
+
+TEST_CASE("ppm_save_empty_image", "[io][ppm]") {
+    Image img;
+    auto tmp = std::filesystem::temp_directory_path() / "test_art_empty.ppm";
+    auto result = ppm::save(tmp, img);
+    CHECK_FALSE(result.has_value());
+    std::filesystem::remove(tmp);
+}
+
+TEST_CASE("generic_load_save_auto_format", "[io]") {
+    Image img(2, 2);
+    img.set_pixel(0, 0, 1.f, 0.f, 0.f, 1.f);
+    img.set_pixel(1, 1, 0.f, 0.f, 1.f, 1.f);
+
+    auto tmp = std::filesystem::temp_directory_path() / "test_art_auto.ppm";
+
+    SaveOptions opts{.exposure = 0.f, .gamma = 1.f};
+    auto save_result = save(tmp, img, ImageFormat::Auto, opts);
+    REQUIRE(save_result.has_value());
+
+    auto load_result = load(tmp, ImageFormat::Auto);
+    REQUIRE(load_result.has_value());
+
+    CHECK(load_result->width() == 2);
+    CHECK(load_result->height() == 2);
+
+    std::filesystem::remove(tmp);
+}
+
+TEST_CASE("generic_load_unknown_extension", "[io]") {
+    auto result = load("/some/file.xyz");
+    CHECK_FALSE(result.has_value());
+    CHECK(result.error().find("Unknown") != std::string::npos);
+}
+
+TEST_CASE("format_support_queries", "[io]") {
+    CHECK(has_ppm_support());
+    // EXR and PNG depend on build options; just check they return a bool
+    [[maybe_unused]] bool exr = has_exr_support();
+    [[maybe_unused]] bool png_val = has_png_support();
+}
+
+TEST_CASE("exr_stub_returns_error_when_unavailable", "[io][exr]") {
+    if (!has_exr_support()) {
+        auto result = exr::load("/some/file.exr");
+        CHECK_FALSE(result.has_value());
+        CHECK(result.error().find("not compiled") != std::string::npos);
+
+        Image img(1, 1);
+        auto save_result = exr::save("/some/file.exr", img);
+        CHECK_FALSE(save_result.has_value());
+    }
+}
+
+TEST_CASE("exr_save_load_roundtrip", "[io][exr]") {
+    if (!has_exr_support()) { SKIP("EXR support not compiled"); }
+
+    Image img(4, 3);
+    img.set_pixel(0, 0, 1.f, 0.f, 0.f, 1.f);
+    img.set_pixel(1, 0, 0.f, 1.f, 0.f, 1.f);
+    img.set_pixel(2, 0, 0.f, 0.f, 1.f, 1.f);
+    img.set_pixel(3, 0, 1.f, 1.f, 1.f, 1.f);
+    img.set_pixel(0, 1, 0.5f, 0.5f, 0.5f, 1.f);
+    img.set_pixel(0, 2, 0.f, 0.f, 0.f, 1.f);
+
+    auto tmp = std::filesystem::temp_directory_path() / "test_art_exr.exr";
+
+    auto save_result = exr::save(tmp, img);
+    REQUIRE(save_result.has_value());
+
+    auto load_result = exr::load(tmp);
+    REQUIRE(load_result.has_value());
+
+    auto &loaded = *load_result;
+    CHECK(loaded.width() == 4);
+    CHECK(loaded.height() == 3);
+
+    // EXR uses fp16, so tolerance is larger than 8-bit
+    auto red = loaded.pixel(0, 0);
+    CHECK(red[0] == Catch::Approx(1.f).margin(0.01f));
+    CHECK(red[1] == Catch::Approx(0.f).margin(0.01f));
+    CHECK(red[2] == Catch::Approx(0.f).margin(0.01f));
+
+    auto green = loaded.pixel(1, 0);
+    CHECK(green[0] == Catch::Approx(0.f).margin(0.01f));
+    CHECK(green[1] == Catch::Approx(1.f).margin(0.01f));
+
+    auto gray = loaded.pixel(0, 1);
+    CHECK(gray[0] == Catch::Approx(0.5f).margin(0.01f));
+    CHECK(gray[1] == Catch::Approx(0.5f).margin(0.01f));
+    CHECK(gray[2] == Catch::Approx(0.5f).margin(0.01f));
+
+    std::filesystem::remove(tmp);
+}
+
+TEST_CASE("png_stub_returns_error_when_unavailable", "[io][png]") {
+    if (!has_png_support()) {
+        auto result = png::load("/some/file.png");
+        CHECK_FALSE(result.has_value());
+        CHECK(result.error().find("not compiled") != std::string::npos);
+
+        Image img(1, 1);
+        auto save_result = png::save("/some/file.png", img);
+        CHECK_FALSE(save_result.has_value());
+    }
+}
+
+TEST_CASE("png_save_load_roundtrip", "[io][png]") {
+    if (!has_png_support()) { SKIP("PNG support not compiled"); }
+
+    Image img(4, 3);
+    img.set_pixel(0, 0, 1.f, 0.f, 0.f, 1.f);
+    img.set_pixel(1, 0, 0.f, 1.f, 0.f, 1.f);
+    img.set_pixel(2, 0, 0.f, 0.f, 1.f, 1.f);
+    img.set_pixel(3, 0, 1.f, 1.f, 1.f, 1.f);
+    img.set_pixel(0, 1, 0.5f, 0.5f, 0.5f, 1.f);
+    img.set_pixel(0, 2, 0.f, 0.f, 0.f, 1.f);
+
+    auto tmp = std::filesystem::temp_directory_path() / "test_art_png.png";
+
+    // Save with gamma=1 for predictable roundtrip
+    SaveOptions opts{.exposure = 0.f, .gamma = 1.f};
+    auto save_result = png::save(tmp, img, opts);
+    REQUIRE(save_result.has_value());
+
+    auto load_result = png::load(tmp);
+    REQUIRE(load_result.has_value());
+
+    auto &loaded = *load_result;
+    CHECK(loaded.width() == 4);
+    CHECK(loaded.height() == 3);
+
+    // PNG is 8-bit, so tolerance matches PPM
+    auto red = loaded.pixel(0, 0);
+    CHECK(red[0] == Catch::Approx(1.f).margin(1.f / 255.f));
+    CHECK(red[1] == Catch::Approx(0.f).margin(1.f / 255.f));
+    CHECK(red[2] == Catch::Approx(0.f).margin(1.f / 255.f));
+
+    auto green = loaded.pixel(1, 0);
+    CHECK(green[0] == Catch::Approx(0.f).margin(1.f / 255.f));
+    CHECK(green[1] == Catch::Approx(1.f).margin(1.f / 255.f));
+
+    auto gray = loaded.pixel(0, 1);
+    CHECK(gray[0] == Catch::Approx(0.5f).margin(1.f / 255.f));
+    CHECK(gray[1] == Catch::Approx(0.5f).margin(1.f / 255.f));
+    CHECK(gray[2] == Catch::Approx(0.5f).margin(1.f / 255.f));
+
+    std::filesystem::remove(tmp);
+}


### PR DESCRIPTION
## Summary

Implements Phase 3 of the ART viewer plan: a real pixel buffer and image I/O infrastructure.

### art::Image (PBRT Film-style pixel buffer)
- Direct pixel access (`set_pixel`/`pixel`) and weighted sample accumulation (`add_sample`/`resolved_pixel`)
- Bulk operations: `set_scanline`, `set_tile`, `pixels()` span, `raw_pixels()`
- Atomic progress tracking (`increment_progress`/`pixels_completed`/`progress_fraction`)
- Atomic dirty tracking (`version()` + `set_on_update()` callback)
- Tone-mapped conversion (`to_rgba8` with exposure/gamma)
- Move-only semantics (explicit move ctor/assignment due to `std::atomic` members)
- 21 test cases, 246 assertions

### Camera::render() → Image
- No longer prints ASCII to stdout
- Creates `Image(nx, ny)`, writes white pixels for hits, black for misses
- Calls `increment_progress()` per pixel

### Image I/O
- Generic `art::io::load()`/`art::io::save()` dispatch on file extension (Auto mode) or explicit `ImageFormat` enum
- **PPM**: always available, no dependencies (P6 binary load + tone-mapped save)
- **EXR**: optional via `-Dexr=true` (tinyexr subproject wrap with miniz)
- **PNG**: optional via `-Dpng=true` (stb_image/stb_image_write subproject wrap)
- Format stubs return descriptive error when support not compiled
- `has_exr_support()` / `has_png_support()` / `has_ppm_support()` queries
- Roundtrip tests for all three formats (EXR/PNG tests SKIP when not compiled)

### Build
- Default build (no I/O libs): 31 test cases, 274 assertions, 2 skipped
- Full build (`-Dexr=true -Dpng=true`): 31 test cases, 292 assertions, 0 skipped