### PR TITLE
refactor: modernize meson build to use dependency() and override_dependency()

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -9,16 +9,9 @@ spdlog_version = '>=1.9.2'
 
 
 
-cc = meson.get_compiler('cpp')
-dl_lib = cc.find_library('dl')
-
-
 spdlog_dep = dependency('spdlog', version: spdlog_version, default_options: ['tests=disabled'])
 
-zipper_proj = subproject('zipper', default_options: {'testing': false, 'examples': false})
-zipper_dep = zipper_proj.get_variable('zipper_dep')
-
-TBB_dep = dependency('tbb')
+zipper_dep = dependency('zipper', default_options: ['testing=false', 'examples=false'])
 
 required_deps = [zipper_dep]
 internal_deps = [spdlog_dep] + required_deps
@@ -58,6 +51,8 @@ art_dep = declare_dependency(
   link_with: art_lib,
   dependencies: required_deps,
   include_directories: include_dirs)
+meson.override_dependency('art', art_dep)
+meson.override_dependency('art-headers', art_headers_dep)
 
 
 art_exec = executable('art', 'src/main.cpp', dependencies: [art_dep] + internal_deps)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,2 +1,3 @@
 option('testing', type : 'boolean', value : true, description : 'Enable tests')
 option('examples', type : 'boolean', value : true, description : 'Build examples')
+option('viewer', type : 'boolean', value : false, description : 'Build viewer tool via balsa::visualization')

--- a/subprojects/zipper.wrap
+++ b/subprojects/zipper.wrap
@@ -3,3 +3,6 @@ url = https://github.com/mtao/zipper.git
 # currently using this repo to dogfood, so i just want the most up-to-date version for now
 revision = main
 #revision = 55cedeeed9836f5656a607d34d770d9d364fb9ad
+
+[provide]
+zipper = zipper_dep


### PR DESCRIPTION
## Summary

- Switch zipper consumption from `subproject().get_variable()` to `dependency('zipper')` with `[provide]` section in wrap file
- Add `meson.override_dependency('art', art_dep)` and `meson.override_dependency('art-headers', art_headers_dep)` so downstream projects can consume ART via `dependency()`
- Remove dead code: unused `dl_lib` (`cc.find_library('dl')`) and unused `TBB_dep` (`dependency('tbb')`) — both were declared but never added to any dependency list
- Add `viewer` option to `meson_options.txt` for future balsa::visualization integration

Part of the cross-project meson modernization effort (zipper PR #12, cpp-template PR #1, quiver PR #7, balsa PR #6, archer PR #3).

## Testing

1 test suite passes (145 assertions in 2 test cases). Build produces 17 targets successfully.

## Note

PR #2 (`feature/image-and-io`) adds EXR/PNG I/O with tinyexr and stb subprojects — those will need similar modernization (switch to `dependency()`) when rebased on top of this.