### PR TITLE
chore: replace #pragma once with old-style include guards

### DIFF
--- a/include/art/Camera.hpp
+++ b/include/art/Camera.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#if !defined(ART_CAMERA_HPP)
+#define ART_CAMERA_HPP
 
 #include "art/Image.hpp"
 #include "art/Point.hpp"
@@ -23,3 +24,4 @@ class ART_API Camera {
     utils::Isometry _camera_transform;
 };
 }  // namespace art
+#endif

--- a/include/art/Image.hpp
+++ b/include/art/Image.hpp
@@ -1,5 +1,7 @@
-#pragma once
+#if !defined(ART_IMAGE_HPP)
+#define ART_IMAGE_HPP
 
 namespace art {
 class Image {};
 }  // namespace art
+#endif

--- a/include/art/Intersection.hpp
+++ b/include/art/Intersection.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#if !defined(ART_INTERSECTION_HPP)
+#define ART_INTERSECTION_HPP
 #include "art/types.hpp"
 
 namespace art {
@@ -10,3 +11,4 @@ struct Intersection {
     // std::shared_ptr<Material> material = nullptr;
 };
 }  // namespace art
+#endif

--- a/include/art/Point.hpp
+++ b/include/art/Point.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#if !defined(ART_POINT_HPP)
+#define ART_POINT_HPP
 #include "art/Rational.hpp"
 #include "art/export.hpp"
 #include "art/zipper_types.hpp"
@@ -76,4 +77,5 @@ struct std::formatter<art::Point> : std::formatter<std::string> {
 
 #if !defined(ART_REDUCE_INLINING)
 #include "Point.hxx"
+#endif
 #endif

--- a/include/art/Point.hxx
+++ b/include/art/Point.hxx
@@ -1,4 +1,5 @@
-#pragma once
+#if !defined(ART_POINT_HXX)
+#define ART_POINT_HXX
 #include "art/Point.hpp"
 
 #include <limits>
@@ -160,3 +161,4 @@ ART_INLINE bool operator==(const Point& a, const Point& b) {
 }
 
 }  // namespace art
+#endif

--- a/include/art/Rational.hpp
+++ b/include/art/Rational.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#if !defined(ART_RATIONAL_HPP)
+#define ART_RATIONAL_HPP
 
 #include <format>
 #include <string>
@@ -80,4 +81,5 @@ ART_API Rational sqrt(const Rational& r);
 
 #if !defined(ART_REDUCE_INLINING)
 #include "Rational.hxx"
+#endif
 #endif

--- a/include/art/Rational.hxx
+++ b/include/art/Rational.hxx
@@ -1,4 +1,5 @@
-#pragma once
+#if !defined(ART_RATIONAL_HXX)
+#define ART_RATIONAL_HXX
 #include <cmath>
 
 #include "art/Rational.hpp"
@@ -56,3 +57,4 @@ ART_INLINE std::weak_ordering Rational::operator<=>(const Rational& o) const {
 }
 
 }  // namespace art
+#endif

--- a/include/art/Ray.hpp
+++ b/include/art/Ray.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#if !defined(ART_RAY_HPP)
+#define ART_RAY_HPP
 #include "art/Intersection.hpp"
 #include "art/Point.hpp"
 #include "art/export.hpp"
@@ -16,3 +17,4 @@ struct ART_API Ray {
 };
 ART_API std::string format_as(const Ray& r);
 }  // namespace art
+#endif

--- a/include/art/export.hpp
+++ b/include/art/export.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#if !defined(ART_EXPORT_HPP)
+#define ART_EXPORT_HPP
 
 #ifdef _WIN32
 #ifdef ART_EXPORTS
@@ -8,4 +9,5 @@
 #endif
 #else
 #define ART_API __attribute__((visibility("default")))
+#endif
 #endif

--- a/include/art/geometry/Geometry.hpp
+++ b/include/art/geometry/Geometry.hpp
@@ -1,6 +1,5 @@
 #if !defined(ART_GEOMETRY_GEOMETRY_HPP)
 #define ART_GEOMETRY_GEOMETRY_HPP
-#pragma once
 #include <memory>
 #include <optional>
 

--- a/include/art/geometry/Line.hpp
+++ b/include/art/geometry/Line.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#if !defined(ART_GEOMETRY_LINE_HPP)
+#define ART_GEOMETRY_LINE_HPP
 #include "art/zipper_types.hpp"
 #include "art/export.hpp"
 #include "art/Point.hpp"
@@ -71,3 +72,4 @@ struct ART_API Line : public Vector6d {
     operator std::string() const;
 };
 }  // namespace art
+#endif

--- a/include/art/geometry/Sphere.hpp
+++ b/include/art/geometry/Sphere.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#if !defined(ART_GEOMETRY_SPHERE_HPP)
+#define ART_GEOMETRY_SPHERE_HPP
 #include "art/export.hpp"
 #include "art/geometry/Geometry.hpp"
 
@@ -14,3 +15,4 @@ class ART_API Sphere : public Geometry {
     Rational radius = 1.;
 };
 }  // namespace art::geometry
+#endif

--- a/include/art/internal/common.hpp
+++ b/include/art/internal/common.hpp
@@ -1,6 +1,8 @@
-#pragma once
+#if !defined(ART_INTERNAL_COMMON_HPP)
+#define ART_INTERNAL_COMMON_HPP
 #if defined(ART_REDUCE_INLINING)
 #define ART_INLINE
 #else
 #define ART_INLINE inline
+#endif
 #endif

--- a/include/art/objects/InternalSceneNode.hpp
+++ b/include/art/objects/InternalSceneNode.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#if !defined(ART_OBJECTS_INTERNALSCENENODE_HPP)
+#define ART_OBJECTS_INTERNALSCENENODE_HPP
 #include "art/export.hpp"
 #include "art/objects/SceneNode.hpp"
 
@@ -18,3 +19,4 @@ class ART_API InternalSceneNode : public SceneNode {
     std::vector<SceneNode::Ptr> _children;
 };
 }  // namespace art::objects
+#endif

--- a/include/art/objects/Object.hpp
+++ b/include/art/objects/Object.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#if !defined(ART_OBJECTS_OBJECT_HPP)
+#define ART_OBJECTS_OBJECT_HPP
 #include <memory>
 
 #include "art/export.hpp"
@@ -25,3 +26,4 @@ class ART_API Object : public SceneNode {
     // AffineTransform _transform;
 };
 }  // namespace art::objects
+#endif

--- a/include/art/objects/SceneNode.hpp
+++ b/include/art/objects/SceneNode.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#if !defined(ART_OBJECTS_SCENENODE_HPP)
+#define ART_OBJECTS_SCENENODE_HPP
 #include <memory>
 #include <optional>
 
@@ -39,3 +40,4 @@ class ART_API SceneNode {
     utils::AffineTransform _transform;
 };
 }  // namespace art::objects
+#endif

--- a/include/art/types.hpp
+++ b/include/art/types.hpp
@@ -1,4 +1,6 @@
-#pragma once
+#if !defined(ART_TYPES_HPP)
+#define ART_TYPES_HPP
 #include "art/geometry/Line.hpp"
 #include "art/Point.hpp"
 #include "art/Rational.hpp"
+#endif

--- a/include/art/utils/AffineTransform.hpp
+++ b/include/art/utils/AffineTransform.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#if !defined(ART_UTILS_AFFINETRANSFORM_HPP)
+#define ART_UTILS_AFFINETRANSFORM_HPP
 
 #include <zipper/transform/transform.hpp>
 
@@ -12,3 +13,4 @@ using Isometry = zipper::transform::Isometry<double, 3>;
 using ProjectiveTransform = zipper::transform::ProjectiveTransform<double, 3>;
 
 }  // namespace art::utils
+#endif

--- a/include/art/zipper_types.hpp
+++ b/include/art/zipper_types.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#if !defined(ART_ZIPPER_TYPES_HPP)
+#define ART_ZIPPER_TYPES_HPP
 
 #include <zipper/Form.hpp>
 #include <zipper/Matrix.hpp>
@@ -31,3 +32,4 @@ concept Vector3Like = zipper::concepts::Vector<T> &&
                       zipper::concepts::ValidExtents<T, 3>;
 
 }  // namespace art
+#endif

--- a/subprojects/mdspan.wrap
+++ b/subprojects/mdspan.wrap
@@ -1,0 +1,2 @@
+[wrap-redirect]
+filename = zipper/subprojects/mdspan.wrap


### PR DESCRIPTION
## Summary
- Convert all 19 headers from `#pragma once` to `#if !defined(GUARD)` / `#define GUARD` / `#endif` style
- Guard names follow `ART_PATH_COMPONENTS_HPP` convention, derived from the header path relative to the include root
- Also removes a stale duplicate `#pragma once` from `Geometry.hpp` which already had old-style guards
- Builds and tests pass