### PR TITLE
feat: Lua table DSL for scene description

### DIFF
--- a/include/art/geometry/Triangle.hpp
+++ b/include/art/geometry/Triangle.hpp
@@ -29,6 +29,11 @@ class ART_API Triangle : public Geometry {
     auto intersect(const Ray &ray, std::optional<Intersection> &isect) const
         -> bool override;
 
+    // Accessors for serialization / introspection
+    auto vertices() const -> const std::array<Vector3d, 3> &;
+    auto normals() const -> const std::optional<std::array<Vector3d, 3>> &;
+    auto uvs() const -> const std::optional<std::array<Vector2d, 3>> &;
+
   private:
     std::array<Vector3d, 3> m_vertices;
     std::optional<std::array<Vector3d, 3>> m_normals;

--- a/include/art/lua/bindings.hpp
+++ b/include/art/lua/bindings.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <sol/forward.hpp>
+
+namespace art::lua {
+
+/// Register ART types into a sol::state or sol::state_view.
+///
+/// Binds geometry types (Sphere, Box, Plane, etc.), scene graph nodes
+/// (Object, InternalSceneNode), Camera, Image, and transform utilities
+/// into an "art" global Lua table.
+///
+/// Also loads quiver Lua bindings so scene scripts can use
+/// quiver.read_mesh(), quiver.ObjReader, etc. for mesh I/O.
+void load_bindings(sol::state_view lua);
+
+} // namespace art::lua

--- a/include/art/lua/scene_loader.hpp
+++ b/include/art/lua/scene_loader.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <cstddef>
+#include <expected>
+#include <filesystem>
+#include <memory>
+#include <string>
+
+#include "art/Camera.hpp"
+#include "art/export.hpp"
+
+namespace art {
+class Image;
+}
+
+namespace art::objects {
+class SceneNode;
+}
+
+namespace art::lua {
+
+/// Parsed scene description from a Lua table DSL script.
+struct ART_API SceneDescription {
+    std::shared_ptr<objects::SceneNode> root;
+    Camera camera{
+        Camera::lookAt(Point(0, 0, 5), Point(0, 0, 0), Point(0, 1, 0))};
+    size_t width = 800;
+    size_t height = 600;
+    std::string output_path = "output.ppm";
+    std::string accelerator = "bvh";
+};
+
+/// Load a scene from a Lua script file.
+/// The script must return a table with the scene description.
+ART_API auto load_scene(const std::filesystem::path &script_path)
+    -> std::expected<SceneDescription, std::string>;
+
+/// Load a scene from a Lua source string.
+ART_API auto load_scene_from_string(const std::string &lua_source)
+    -> std::expected<SceneDescription, std::string>;
+
+/// Render a loaded scene description and return the resulting image.
+ART_API auto render_scene(const SceneDescription &desc)
+    -> std::expected<Image, std::string>;
+
+} // namespace art::lua

--- a/include/art/lua/scene_serializer.hpp
+++ b/include/art/lua/scene_serializer.hpp
@@ -1,0 +1,18 @@
+#pragma once
+/// @file include/art/lua/scene_serializer.hpp
+/// Serialize a SceneDescription back to Lua table DSL (round-trip).
+
+#include <string>
+
+#include "art/export.hpp"
+
+namespace art::lua {
+
+struct SceneDescription;
+
+/// Serialize a scene to a Lua table string that can be loaded by
+/// load_scene_from_string(). The output is a complete Lua script that
+/// returns the scene table.
+ART_API auto serialize_scene(const SceneDescription &desc) -> std::string;
+
+} // namespace art::lua

--- a/meson.build
+++ b/meson.build
@@ -68,6 +68,7 @@ if lua_enabled
       'src/lua/bind_image.cpp',
       'src/lua/bind_transform.cpp',
       'src/lua/scene_loader.cpp',
+      'src/lua/scene_serializer.cpp',
   ]
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -13,12 +13,21 @@ spdlog_dep = dependency('spdlog', version: spdlog_version, default_options: ['te
 
 zipper_dep = dependency('zipper', default_options: ['testing=false', 'examples=false'])
 
-quiver_dep = dependency('quiver', default_options: [
+# Determine lua option early so quiver can be built with lua support if needed.
+lua_enabled = get_option('lua')
+
+quiver_opts = [
     'testing=false',
     'examples=false',
     'tools=false',
-    'lua=false',
-])
+]
+if lua_enabled
+  quiver_opts += 'lua=true'
+else
+  quiver_opts += 'lua=false'
+endif
+
+quiver_dep = dependency('quiver', default_options: quiver_opts)
 
 required_deps = [zipper_dep, quiver_dep]
 internal_deps = [spdlog_dep] + required_deps
@@ -38,6 +47,28 @@ if get_option('png')
   stb_dep = stb_proj.get_variable('stb_dep')
   internal_deps += stb_dep
   io_cpp_args += '-DART_HAS_PNG=1'
+endif
+
+# Optional: sol2 Lua bindings for scene description.
+# sol2's meson.build pulls lua as a dependency internally.
+# lua_enabled was determined above (before quiver dep).
+lua_sources = []
+lua_deps = []
+lua_cpp_args = []
+if lua_enabled
+  sol2_proj = subproject('sol2')
+  sol2_dep = sol2_proj.get_variable('sol2_dep')
+  lua_deps += [sol2_dep]
+  lua_cpp_args += '-DART_HAS_LUA=1'
+  lua_sources += [
+      'src/lua/bindings.cpp',
+      'src/lua/bind_geometry.cpp',
+      'src/lua/bind_scene.cpp',
+      'src/lua/bind_camera.cpp',
+      'src/lua/bind_image.cpp',
+      'src/lua/bind_transform.cpp',
+      'src/lua/scene_loader.cpp',
+  ]
 endif
 
 lib_sources = [
@@ -80,10 +111,10 @@ art_headers_dep = declare_dependency(
   include_directories: include_dirs)
 
 # Compiled library
-art_lib = library('art', lib_sources,
+art_lib = library('art', lib_sources + lua_sources,
   include_directories: include_dirs,
-  dependencies: internal_deps,
-  cpp_args: ['-DART_EXPORTS'] + io_cpp_args,
+  dependencies: internal_deps + lua_deps,
+  cpp_args: ['-DART_EXPORTS'] + io_cpp_args + lua_cpp_args,
   gnu_symbol_visibility: 'hidden')
 
 # Full dependency (headers + library linking)
@@ -96,6 +127,12 @@ meson.override_dependency('art-headers', art_headers_dep)
 
 
 art_exec = executable('art', 'src/main.cpp', dependencies: [art_dep] + internal_deps)
+
+if lua_enabled
+  art_lua_exec = executable('art-lua', 'src/art_lua.cpp',
+    dependencies: [art_dep] + internal_deps + lua_deps,
+    cpp_args: lua_cpp_args)
+endif
 
 
 if get_option('testing')

--- a/meson.build
+++ b/meson.build
@@ -136,6 +136,9 @@ if lua_enabled
 endif
 
 
+if get_option('tools')
+  subdir('tools')
+endif
 if get_option('testing')
   subdir('tests')
 endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -3,3 +3,4 @@ option('examples', type : 'boolean', value : true, description : 'Build examples
 option('exr', type : 'boolean', value : false, description : 'EXR image I/O via tinyexr')
 option('png', type : 'boolean', value : false, description : 'PNG image I/O via stb_image')
 option('viewer', type : 'boolean', value : false, description : 'Build viewer tool via balsa::visualization')
+option('lua', type : 'boolean', value : false, description : 'Lua scene description via sol2')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -4,3 +4,4 @@ option('exr', type : 'boolean', value : false, description : 'EXR image I/O via 
 option('png', type : 'boolean', value : false, description : 'PNG image I/O via stb_image')
 option('viewer', type : 'boolean', value : false, description : 'Build viewer tool via balsa::visualization')
 option('lua', type : 'boolean', value : false, description : 'Lua scene description via sol2')
+option('tools', type : 'boolean', value : true, description : 'Install Lua tool scripts')

--- a/scenes/cornell_box.lua
+++ b/scenes/cornell_box.lua
@@ -1,0 +1,65 @@
+-- scenes/cornell_box.lua
+-- Cornell box approximation using ART's current geometry primitives.
+-- No materials/lights yet — just geometry with normal-based coloring.
+
+-- Box walls as scaled/translated planes
+local function wall(tx, ty, tz, rx, ry, rz, angle)
+    return {
+        type = "plane",
+        transform = {
+            translate = {tx, ty, tz},
+            rotate = {angle = angle, axis = {rx, ry, rz}},
+        },
+    }
+end
+
+return {
+    render = {
+        width = 400,
+        height = 400,
+        output = "cornell_box.ppm",
+        accelerator = "bvh",
+    },
+
+    camera = {
+        position = {0, 0, 4},
+        target = {0, 0, 0},
+        up = {0, 1, 0},
+    },
+
+    scene = {
+        -- Back wall (z = -2)
+        wall(0, 0, -2, 0, 0, 0, 0),
+
+        -- Floor (y = -2)
+        wall(0, -2, 0, 1, 0, 0, -math.pi / 2),
+
+        -- Ceiling (y = 2)
+        wall(0, 2, 0, 1, 0, 0, math.pi / 2),
+
+        -- Left wall (x = -2)
+        wall(-2, 0, 0, 0, 1, 0, math.pi / 2),
+
+        -- Right wall (x = 2)
+        wall(2, 0, 0, 0, 1, 0, -math.pi / 2),
+
+        -- Tall box
+        {
+            type = "box",
+            transform = {
+                translate = {-0.5, -1, -0.5},
+                rotate = {angle = 0.3, axis = {0, 1, 0}},
+                scale = {1, 2, 1},
+            },
+        },
+
+        -- Short box
+        {
+            type = "box",
+            transform = {
+                translate = {0.7, -1.5, 0.5},
+                rotate = {angle = -0.2, axis = {0, 1, 0}},
+            },
+        },
+    },
+}

--- a/scenes/mesh_demo.lua
+++ b/scenes/mesh_demo.lua
@@ -1,0 +1,37 @@
+-- scenes/mesh_demo.lua
+-- Demonstrates inline mesh construction via Lua tables.
+
+return {
+    render = {
+        width = 200,
+        height = 200,
+        output = "mesh_demo.ppm",
+        accelerator = "bvh",
+    },
+
+    camera = {
+        position = {2, 2, 5},
+        target = {0, 0, 0},
+        up = {0, 1, 0},
+    },
+
+    scene = {
+        -- A cube mesh
+        {
+            type = "cube_mesh",
+            transform = {
+                rotate = {angle = 0.5, axis = {1, 1, 0}},
+            },
+        },
+
+        -- A custom triangle
+        {
+            type = "triangle",
+            vertices = {
+                {-2, -1, 0},
+                {-1, -1, 0},
+                {-1.5, 0, 0},
+            },
+        },
+    },
+}

--- a/scenes/sphere.lua
+++ b/scenes/sphere.lua
@@ -1,0 +1,21 @@
+-- scenes/sphere.lua
+-- Simple sphere scene for ART Lua DSL.
+
+return {
+    render = {
+        width = 200,
+        height = 200,
+        output = "sphere.ppm",
+        accelerator = "bvh",
+    },
+
+    camera = {
+        position = {0, 0, 5},
+        target = {0, 0, 0},
+        up = {0, 1, 0},
+    },
+
+    scene = {
+        { type = "sphere" },
+    },
+}

--- a/scenes/transforms.lua
+++ b/scenes/transforms.lua
@@ -1,0 +1,65 @@
+-- scenes/transforms.lua
+-- Demonstrates transform composition: multiple objects with
+-- translation, rotation, and scale.
+
+return {
+    render = {
+        width = 400,
+        height = 300,
+        output = "transforms.ppm",
+        accelerator = "bvh",
+    },
+
+    camera = {
+        position = {0, 2, 8},
+        target = {0, 0, 0},
+        up = {0, 1, 0},
+    },
+
+    scene = {
+        -- Ground plane
+        {
+            type = "plane",
+            transform = {
+                translate = {0, -1, 0},
+                rotate = {angle = -math.pi / 2, axis = {1, 0, 0}},
+            },
+        },
+
+        -- Sphere on the left
+        {
+            type = "sphere",
+            transform = {
+                translate = {-2, 0, 0},
+                scale = 0.5,
+            },
+        },
+
+        -- Rotated box in the center
+        {
+            type = "box",
+            transform = {
+                translate = {0, 0, 0},
+                rotate = {angle = 0.8, axis = {0, 1, 0}},
+            },
+        },
+
+        -- Cylinder on the right
+        {
+            type = "cylinder",
+            transform = {
+                translate = {2, -1, 0},
+                scale = {0.5, 2, 0.5},
+            },
+        },
+
+        -- Disk floating above
+        {
+            type = "disk",
+            transform = {
+                translate = {0, 2, 0},
+                scale = 1.5,
+            },
+        },
+    },
+}

--- a/src/art_lua.cpp
+++ b/src/art_lua.cpp
@@ -1,0 +1,107 @@
+/// @file src/art_lua.cpp
+/// CLI runner for ART Lua scene description files.
+///
+/// Usage: art-lua scene.lua [--output path] [--width N] [--height N]
+
+#include <format>
+#include <iostream>
+#include <string>
+
+#include <spdlog/spdlog.h>
+
+#include "art/io/image_io.hpp"
+#include "art/lua/scene_loader.hpp"
+
+static void print_usage(const char *prog) {
+    std::cerr << std::format(
+        "Usage: {} <scene.lua> [options]\n"
+        "\n"
+        "Options:\n"
+        "  --output <path>   Output image path (overrides scene)\n"
+        "  --width <N>       Image width (overrides scene)\n"
+        "  --height <N>      Image height (overrides scene)\n"
+        "  --accel <type>    Accelerator: 'bvh' or 'linear'\n"
+        "  --help            Show this help\n",
+        prog);
+}
+
+int main(int argc, char *argv[]) {
+    if (argc < 2) {
+        print_usage(argv[0]);
+        return 1;
+    }
+
+    std::string scene_path;
+    std::string output_override;
+    int width_override = -1;
+    int height_override = -1;
+    std::string accel_override;
+
+    for (int i = 1; i < argc; ++i) {
+        std::string arg = argv[i];
+        if (arg == "--help" || arg == "-h") {
+            print_usage(argv[0]);
+            return 0;
+        }
+        if (arg == "--output" && i + 1 < argc) {
+            output_override = argv[++i];
+        } else if (arg == "--width" && i + 1 < argc) {
+            width_override = std::stoi(argv[++i]);
+        } else if (arg == "--height" && i + 1 < argc) {
+            height_override = std::stoi(argv[++i]);
+        } else if (arg == "--accel" && i + 1 < argc) {
+            accel_override = argv[++i];
+        } else if (arg[0] != '-') {
+            scene_path = arg;
+        } else {
+            std::cerr << std::format("Unknown option: {}\n", arg);
+            print_usage(argv[0]);
+            return 1;
+        }
+    }
+
+    if (scene_path.empty()) {
+        std::cerr << "Error: no scene file specified\n";
+        print_usage(argv[0]);
+        return 1;
+    }
+
+    // Load scene
+    auto desc_result = art::lua::load_scene(scene_path);
+    if (!desc_result) {
+        std::cerr << std::format("Error loading scene: {}\n",
+                                 desc_result.error());
+        return 1;
+    }
+    auto &desc = *desc_result;
+
+    // Apply CLI overrides
+    if (width_override > 0) desc.width = static_cast<size_t>(width_override);
+    if (height_override > 0) desc.height = static_cast<size_t>(height_override);
+    if (!output_override.empty()) desc.output_path = output_override;
+    if (!accel_override.empty()) desc.accelerator = accel_override;
+
+    spdlog::info("scene: {} -> {}x{} -> {}",
+                 scene_path,
+                 desc.width,
+                 desc.height,
+                 desc.output_path);
+
+    // Render
+    auto img_result = art::lua::render_scene(desc);
+    if (!img_result) {
+        std::cerr << std::format("Error rendering: {}\n", img_result.error());
+        return 1;
+    }
+
+    // Save
+    auto save_result = art::io::save(desc.output_path, *img_result);
+    if (!save_result) {
+        std::cerr << std::format("Error saving image: {}\n",
+                                 std::string(save_result.error()));
+        return 1;
+    }
+
+    spdlog::info("saved: {}", desc.output_path);
+    return 0;
+}

--- a/src/geometry/Triangle.cpp
+++ b/src/geometry/Triangle.cpp
@@ -25,6 +25,19 @@ Triangle::Triangle(Vector3d v0,
                    Vector2d uv2)
   : m_vertices{v0, v1, v2}, m_uvs{std::array<Vector2d, 3>{uv0, uv1, uv2}} {}
 
+auto Triangle::vertices() const -> const std::array<Vector3d, 3> & {
+    return m_vertices;
+}
+
+auto Triangle::normals() const
+    -> const std::optional<std::array<Vector3d, 3>> & {
+    return m_normals;
+}
+
+auto Triangle::uvs() const -> const std::optional<std::array<Vector2d, 3>> & {
+    return m_uvs;
+}
+
 auto Triangle::bounding_box() const -> Box {
     const auto &v0 = m_vertices[0];
     const auto &v1 = m_vertices[1];

--- a/src/lua/bind_camera.cpp
+++ b/src/lua/bind_camera.cpp
@@ -1,0 +1,28 @@
+/// @file src/lua/bind_camera.cpp
+/// Lua bindings for ART Camera.
+
+#include "bind_internal.hpp"
+
+#include "art/Camera.hpp"
+#include "art/Point.hpp"
+
+namespace art::lua {
+
+void bind_camera(sol::table &tbl) {
+    auto make_camera = [](const sol::table &pos,
+                          const sol::table &target,
+                          const sol::table &up) {
+        return Camera(Camera::lookAt(Point(table_to_vec3(pos)),
+                                     Point(table_to_vec3(target)),
+                                     Point(table_to_vec3(up))));
+    };
+
+    tbl.new_usertype<Camera>("Camera",
+                             sol::call_constructor,
+                             sol::factories(make_camera),
+
+                             "look_at",
+                             make_camera);
+}
+
+} // namespace art::lua

--- a/src/lua/bind_geometry.cpp
+++ b/src/lua/bind_geometry.cpp
@@ -1,0 +1,118 @@
+/// @file src/lua/bind_geometry.cpp
+/// Lua bindings for ART geometry types.
+
+#include "bind_internal.hpp"
+
+#include "art/geometry/Box.hpp"
+#include "art/geometry/Cylinder.hpp"
+#include "art/geometry/Disk.hpp"
+#include "art/geometry/MeshGeometry.hpp"
+#include "art/geometry/Plane.hpp"
+#include "art/geometry/Sphere.hpp"
+#include "art/geometry/Triangle.hpp"
+#include "art/geometry/mesh_utils.hpp"
+
+namespace art::lua {
+
+void bind_geometry(sol::table &tbl) {
+    // ── Sphere ──
+    tbl.new_usertype<geometry::Sphere>(
+        "Sphere", sol::call_constructor, sol::factories([] {
+            return std::make_shared<geometry::Sphere>();
+        }));
+
+    // ── Box ──
+    tbl.new_usertype<geometry::Box>(
+        "Box",
+        sol::call_constructor,
+        sol::factories([] { return std::make_shared<geometry::Box>(); },
+                       [](const sol::table &min_t, const sol::table &max_t) {
+                           auto mn = table_to_vec3(min_t);
+                           auto mx = table_to_vec3(max_t);
+                           return std::make_shared<geometry::Box>(Point(mn),
+                                                                  Point(mx));
+                       }),
+        "min",
+        [](const geometry::Box &b, sol::this_state ts) {
+            Vector3d v = b.min();
+            return vec3_to_table(sol::state_view(ts), v);
+        },
+        "max",
+        [](const geometry::Box &b, sol::this_state ts) {
+            Vector3d v = b.max();
+            return vec3_to_table(sol::state_view(ts), v);
+        });
+
+    // ── Plane ──
+    tbl.new_usertype<geometry::Plane>(
+        "Plane", sol::call_constructor, sol::factories([] {
+            return std::make_shared<geometry::Plane>();
+        }));
+
+    // ── Disk ──
+    tbl.new_usertype<geometry::Disk>(
+        "Disk", sol::call_constructor, sol::factories([] {
+            return std::make_shared<geometry::Disk>();
+        }));
+
+    // ── Cylinder ──
+    tbl.new_usertype<geometry::Cylinder>(
+        "Cylinder", sol::call_constructor, sol::factories([] {
+            return std::make_shared<geometry::Cylinder>();
+        }));
+
+    // ── Triangle ──
+    tbl.new_usertype<geometry::Triangle>(
+        "Triangle",
+        sol::call_constructor,
+        sol::factories([](const sol::table &v0t,
+                          const sol::table &v1t,
+                          const sol::table &v2t) {
+            return std::make_shared<geometry::Triangle>(
+                table_to_vec3(v0t), table_to_vec3(v1t), table_to_vec3(v2t));
+        }));
+
+    // ── MeshGeometry ──
+    tbl.new_usertype<geometry::MeshGeometry>(
+        "MeshGeometry",
+        sol::no_constructor,
+
+        "triangle_count",
+        &geometry::MeshGeometry::triangle_count);
+
+    // ── Factory functions ──
+    tbl.set_function("make_cube_mesh",
+                     [] { return geometry::make_cube_mesh(); });
+
+    tbl.set_function("make_tetrahedron_mesh",
+                     [] { return geometry::make_tetrahedron_mesh(); });
+
+    tbl.set_function(
+        "make_mesh",
+        [](const sol::table &verts_t, const sol::table &tris_t)
+            -> std::shared_ptr<geometry::MeshGeometry> {
+            using Vec3 = std::array<double, 3>;
+            using Tri = std::array<int64_t, 3>;
+
+            std::vector<Vec3> vertices;
+            vertices.reserve(verts_t.size());
+            for (size_t i = 1; i <= verts_t.size(); ++i) {
+                sol::table v = verts_t[i];
+                vertices.push_back(
+                    {v.get_or(1, 0.0), v.get_or(2, 0.0), v.get_or(3, 0.0)});
+            }
+
+            std::vector<Tri> triangles;
+            triangles.reserve(tris_t.size());
+            for (size_t i = 1; i <= tris_t.size(); ++i) {
+                sol::table t = tris_t[i];
+                triangles.push_back({t.get_or<int64_t>(1, 0),
+                                     t.get_or<int64_t>(2, 0),
+                                     t.get_or<int64_t>(3, 0)});
+            }
+
+            return geometry::make_mesh_geometry(vertices, triangles);
+        });
+}
+
+} // namespace art::lua

--- a/src/lua/bind_image.cpp
+++ b/src/lua/bind_image.cpp
@@ -1,0 +1,52 @@
+/// @file src/lua/bind_image.cpp
+/// Lua bindings for ART Image.
+
+#include "bind_internal.hpp"
+
+#include "art/Image.hpp"
+#include "art/io/image_io.hpp"
+
+namespace art::lua {
+
+void bind_image(sol::table &tbl) {
+    tbl.new_usertype<Image>(
+        "Image",
+        sol::no_constructor,
+
+        "width",
+        &Image::width,
+        "height",
+        &Image::height,
+        "progress",
+        &Image::progress_fraction,
+
+        "pixel",
+        [](const Image &img, size_t x, size_t y, sol::this_state ts) {
+            auto px = img.pixel(x, y);
+            sol::table t = sol::state_view(ts).create_table(4, 0);
+            t[1] = px[0];
+            t[2] = px[1];
+            t[3] = px[2];
+            t[4] = px[3];
+            return t;
+        },
+
+        "set_pixel",
+        [](Image &img, size_t x, size_t y, float r, float g, float b) {
+            img.set_pixel(x, y, r, g, b, 1.f);
+        });
+
+    // Image I/O
+    tbl.set_function("save_image",
+                     [](const std::string &path,
+                        const Image &img,
+                        sol::this_state ts) -> std::pair<bool, sol::object> {
+                         auto result = art::io::save(path, img);
+                         if (result) { return {true, sol::lua_nil}; }
+                         return {false,
+                                 sol::make_object(sol::state_view(ts),
+                                                  std::string(result.error()))};
+                     });
+}
+
+} // namespace art::lua

--- a/src/lua/bind_internal.hpp
+++ b/src/lua/bind_internal.hpp
@@ -1,0 +1,105 @@
+#pragma once
+/// @file src/lua/bind_internal.hpp
+/// Shared declarations for per-domain bind_*() functions.
+
+#include <sol/sol.hpp>
+
+#include <zipper/transform/transform.hpp>
+
+#include "art/utils/AffineTransform.hpp"
+#include "art/zipper_types.hpp"
+
+namespace art::lua {
+
+// Forward declarations for bind functions — called by bindings.cpp
+// orchestrator.
+void bind_geometry(sol::table &tbl);
+void bind_scene(sol::table &tbl);
+void bind_camera(sol::table &tbl);
+void bind_image(sol::table &tbl);
+void bind_transform(sol::table &tbl);
+
+// ── Helper: read a Lua table {x, y, z} into a Vector3d ──
+
+inline auto table_to_vec3(const sol::table &t) -> Vector3d {
+    return Vector3d{
+        t.get_or(1, 0.0),
+        t.get_or(2, 0.0),
+        t.get_or(3, 0.0),
+    };
+}
+
+inline auto table_to_vec2(const sol::table &t) -> Vector2d {
+    return Vector2d{
+        t.get_or(1, 0.0),
+        t.get_or(2, 0.0),
+    };
+}
+
+// Push a Vector3d as a Lua table {x, y, z}
+inline auto vec3_to_table(sol::state_view lua, const Vector3d &v)
+    -> sol::table {
+    sol::table t = lua.create_table(3, 0);
+    t[1] = static_cast<double>(v(0));
+    t[2] = static_cast<double>(v(1));
+    t[3] = static_cast<double>(v(2));
+    return t;
+}
+
+inline auto vec2_to_table(sol::state_view lua, const Vector2d &v)
+    -> sol::table {
+    sol::table t = lua.create_table(2, 0);
+    t[1] = static_cast<double>(v(0));
+    t[2] = static_cast<double>(v(1));
+    return t;
+}
+
+// ── Helper: parse a TRS transform table ──
+// Expected format: { translate = {x,y,z}, rotate = {angle=.., axis={..}},
+//                    scale = number_or_vec3 }
+// Composition order: T * R * S (scale applied first).
+
+inline auto parse_transform(const sol::table &t) -> utils::AffineTransform {
+    utils::AffineTransform result{};
+
+    // Scale first (applied to geometry)
+    if (auto scale = t.get<sol::optional<sol::object>>("scale");
+        scale && scale->valid()) {
+        if (scale->is<sol::table>()) {
+            auto v = table_to_vec3(scale->as<sol::table>());
+            result =
+                zipper::transform::Scaling<double>(v).to_transform() * result;
+        } else if (scale->is<double>()) {
+            double s = scale->as<double>();
+            result = zipper::transform::Scaling<double>(Vector3d{s, s, s})
+                         .to_transform()
+                     * result;
+        }
+    }
+
+    // Rotate second
+    if (auto rotate = t.get<sol::optional<sol::table>>("rotate");
+        rotate && rotate->valid()) {
+        double angle = rotate->get_or("angle", 0.0);
+        sol::optional<sol::table> axis_t =
+            rotate->get<sol::optional<sol::table>>("axis");
+        if (axis_t) {
+            auto axis = table_to_vec3(*axis_t);
+            result = zipper::transform::AxisAngleRotation<double>(angle, axis)
+                         .to_transform()
+                     * result;
+        }
+    }
+
+    // Translate last
+    if (auto translate = t.get<sol::optional<sol::table>>("translate");
+        translate && translate->valid()) {
+        auto v = table_to_vec3(*translate);
+        result =
+            zipper::transform::Translation<double>(v).to_transform() * result;
+    }
+
+    return result;
+}
+
+} // namespace art::lua

--- a/src/lua/bind_scene.cpp
+++ b/src/lua/bind_scene.cpp
@@ -1,0 +1,57 @@
+/// @file src/lua/bind_scene.cpp
+/// Lua bindings for ART scene graph nodes.
+
+#include "bind_internal.hpp"
+
+#include "art/geometry/Geometry.hpp"
+#include "art/objects/InternalSceneNode.hpp"
+#include "art/objects/Object.hpp"
+#include "art/objects/SceneNode.hpp"
+
+namespace art::lua {
+
+void bind_scene(sol::table &tbl) {
+    // ── SceneNode (base) ──
+    tbl.new_usertype<objects::SceneNode>(
+        "SceneNode",
+        sol::no_constructor,
+
+        "transform",
+        sol::property(
+            [](const objects::SceneNode &n) -> const utils::AffineTransform & {
+                return n.transform();
+            },
+            [](objects::SceneNode &n, const utils::AffineTransform &xf) {
+                n.transform() = xf;
+            }));
+
+    // ── Object (leaf node with geometry) ──
+    tbl.new_usertype<objects::Object>(
+        "Object",
+        sol::call_constructor,
+        sol::factories([](std::shared_ptr<geometry::Geometry> geom) {
+            return std::make_shared<objects::Object>(*geom);
+        }),
+        sol::base_classes,
+        sol::bases<objects::SceneNode>(),
+
+        "geometry",
+        [](const objects::Object &o) { return o.geometry_ptr(); });
+
+    // ── InternalSceneNode (group node) ──
+    tbl.new_usertype<objects::InternalSceneNode>(
+        "Group",
+        sol::call_constructor,
+        sol::factories([] { return objects::InternalSceneNode::create(); }),
+        sol::base_classes,
+        sol::bases<objects::SceneNode>(),
+
+        "add",
+        [](objects::InternalSceneNode &g, objects::SceneNode::Ptr node) {
+            g.add_node(std::move(node));
+        },
+        "children",
+        [](const objects::InternalSceneNode &g) { return g.children(); });
+}
+
+} // namespace art::lua

--- a/src/lua/bind_transform.cpp
+++ b/src/lua/bind_transform.cpp
@@ -1,0 +1,53 @@
+/// @file src/lua/bind_transform.cpp
+/// Lua bindings for zipper transform types used by ART.
+
+#include "bind_internal.hpp"
+
+#include "art/utils/AffineTransform.hpp"
+
+namespace art::lua {
+
+void bind_transform(sol::table &tbl) {
+    // ── AffineTransform ──
+    tbl.new_usertype<utils::AffineTransform>(
+        "AffineTransform",
+        sol::call_constructor,
+        sol::factories(
+            // Default: identity
+            [] { return utils::AffineTransform{}; }),
+
+        "inverse",
+        [](const utils::AffineTransform &xf) { return xf.inverse(); });
+
+    // ── Transform factory functions ──
+    tbl.set_function(
+        "translation", [](const sol::table &t) -> utils::AffineTransform {
+            auto v = table_to_vec3(t);
+            return zipper::transform::Translation<double>(v).to_transform();
+        });
+
+    tbl.set_function(
+        "rotation",
+        [](double angle, const sol::table &axis) -> utils::AffineTransform {
+            auto a = table_to_vec3(axis);
+            return zipper::transform::AxisAngleRotation<double>(angle, a)
+                .to_transform();
+        });
+
+    tbl.set_function(
+        "scaling", [](const sol::object &arg) -> utils::AffineTransform {
+            if (arg.is<sol::table>()) {
+                auto v = table_to_vec3(arg.as<sol::table>());
+                return zipper::transform::Scaling<double>(v).to_transform();
+            }
+            // Uniform scale
+            double s = arg.as<double>();
+            return zipper::transform::Scaling<double>(Vector3d{s, s, s})
+                .to_transform();
+        });
+
+    // Compose: T * R * S (delegates to shared parse_transform)
+    tbl.set_function("compose_trs", parse_transform);
+}
+
+} // namespace art::lua

--- a/src/lua/bindings.cpp
+++ b/src/lua/bindings.cpp
@@ -1,0 +1,31 @@
+/// @file src/lua/bindings.cpp
+/// Orchestrator: registers all ART types into the "art" Lua table.
+///
+/// Also loads quiver's Lua bindings so scene scripts can use
+/// quiver.read_mesh(), quiver.ObjReader, etc.
+
+#include "art/lua/bindings.hpp"
+
+#include <quiver/lua/bindings.hpp>
+
+#include "bind_internal.hpp"
+
+namespace art::lua {
+
+void load_bindings(sol::state_view lua) {
+    sol::table tbl = lua["art"].get_or_create<sol::table>();
+
+    // Guard against double-registration (same pattern as quiver).
+    if (tbl["Sphere"].valid()) return;
+
+    bind_transform(tbl);
+    bind_geometry(tbl);
+    bind_scene(tbl);
+    bind_camera(tbl);
+    bind_image(tbl);
+
+    // Load quiver bindings so scene scripts can call quiver.read_mesh() etc.
+    quiver::lua::load_bindings(lua);
+}
+
+} // namespace art::lua

--- a/src/lua/scene_loader.cpp
+++ b/src/lua/scene_loader.cpp
@@ -1,0 +1,328 @@
+/// @file src/lua/scene_loader.cpp
+/// Lua table DSL scene loader: parses a Lua table into a SceneDescription.
+
+#include "art/lua/scene_loader.hpp"
+
+#include "bind_internal.hpp"
+
+#include <filesystem>
+#include <format>
+
+#include <spdlog/spdlog.h>
+
+#include "art/Camera.hpp"
+#include "art/Image.hpp"
+#include "art/Point.hpp"
+#include "art/accel/BVHAccelerator.hpp"
+#include "art/accel/LinearAccelerator.hpp"
+#include "art/geometry/Box.hpp"
+#include "art/geometry/Cylinder.hpp"
+#include "art/geometry/Disk.hpp"
+#include "art/geometry/MeshGeometry.hpp"
+#include "art/geometry/Plane.hpp"
+#include "art/geometry/Sphere.hpp"
+#include "art/geometry/Triangle.hpp"
+#include "art/geometry/mesh_utils.hpp"
+#include "art/io/image_io.hpp"
+#include "art/lua/bindings.hpp"
+#include "art/objects/InternalSceneNode.hpp"
+#include "art/objects/Object.hpp"
+
+namespace art::lua {
+
+namespace {
+
+    // ── Geometry construction from table ──
+
+    auto make_geometry(const sol::table &node)
+        -> std::shared_ptr<const geometry::Geometry> {
+        std::string type = node.get_or<std::string>("type", "");
+
+        if (type == "sphere") { return std::make_shared<geometry::Sphere>(); }
+        if (type == "box") {
+            sol::optional<sol::table> min_t =
+                node.get<sol::optional<sol::table>>("min");
+            sol::optional<sol::table> max_t =
+                node.get<sol::optional<sol::table>>("max");
+            if (min_t && max_t) {
+                auto mn = table_to_vec3(*min_t);
+                auto mx = table_to_vec3(*max_t);
+                return std::make_shared<geometry::Box>(Point(mn), Point(mx));
+            }
+            return std::make_shared<geometry::Box>();
+        }
+        if (type == "plane") { return std::make_shared<geometry::Plane>(); }
+        if (type == "disk") { return std::make_shared<geometry::Disk>(); }
+        if (type == "cylinder") {
+            return std::make_shared<geometry::Cylinder>();
+        }
+        if (type == "triangle") {
+            sol::optional<sol::table> verts =
+                node.get<sol::optional<sol::table>>("vertices");
+            if (!verts || verts->size() < 3) {
+                spdlog::warn("triangle node missing 'vertices' (need 3 vec3)");
+                return nullptr;
+            }
+            sol::table v0t = (*verts)[1];
+            sol::table v1t = (*verts)[2];
+            sol::table v2t = (*verts)[3];
+            auto v0 = table_to_vec3(v0t);
+            auto v1 = table_to_vec3(v1t);
+            auto v2 = table_to_vec3(v2t);
+
+            // Optional normals
+            sol::optional<sol::table> normals =
+                node.get<sol::optional<sol::table>>("normals");
+            if (normals && normals->size() >= 3) {
+                sol::table n0t = (*normals)[1];
+                sol::table n1t = (*normals)[2];
+                sol::table n2t = (*normals)[3];
+                return std::make_shared<geometry::Triangle>(v0,
+                                                            v1,
+                                                            v2,
+                                                            table_to_vec3(n0t),
+                                                            table_to_vec3(n1t),
+                                                            table_to_vec3(n2t));
+            }
+            return std::make_shared<geometry::Triangle>(v0, v1, v2);
+        }
+        if (type == "mesh") {
+            sol::optional<sol::table> verts_t =
+                node.get<sol::optional<sol::table>>("vertices");
+            sol::optional<sol::table> tris_t =
+                node.get<sol::optional<sol::table>>("triangles");
+            if (!verts_t || !tris_t) {
+                spdlog::warn("mesh node missing 'vertices' or 'triangles'");
+                return nullptr;
+            }
+
+            using Vec3 = std::array<double, 3>;
+            using Tri = std::array<int64_t, 3>;
+
+            std::vector<Vec3> vertices;
+            vertices.reserve(verts_t->size());
+            for (size_t i = 1; i <= verts_t->size(); ++i) {
+                sol::table v = (*verts_t)[i];
+                vertices.push_back(
+                    {v.get_or(1, 0.0), v.get_or(2, 0.0), v.get_or(3, 0.0)});
+            }
+
+            std::vector<Tri> triangles;
+            triangles.reserve(tris_t->size());
+            for (size_t i = 1; i <= tris_t->size(); ++i) {
+                sol::table t = (*tris_t)[i];
+                triangles.push_back({t.get_or<int64_t>(1, 0),
+                                     t.get_or<int64_t>(2, 0),
+                                     t.get_or<int64_t>(3, 0)});
+            }
+
+            return geometry::make_mesh_geometry(vertices, triangles);
+        }
+        if (type == "cube_mesh") { return geometry::make_cube_mesh(); }
+
+        return nullptr;
+    }
+
+    // ── Scene node construction (recursive) ──
+
+    auto parse_node(const sol::table &node) -> objects::SceneNode::Ptr {
+        std::string type = node.get_or<std::string>("type", "");
+
+        // Parse transform if present
+        utils::AffineTransform xf{};
+        sol::optional<sol::table> xf_t =
+            node.get<sol::optional<sol::table>>("transform");
+        if (xf_t) { xf = parse_transform(*xf_t); }
+
+        if (type == "group") {
+            auto group = objects::InternalSceneNode::create();
+            group->transform() = xf;
+
+            sol::optional<sol::table> children =
+                node.get<sol::optional<sol::table>>("children");
+            if (children) {
+                for (size_t i = 1; i <= children->size(); ++i) {
+                    sol::table child = (*children)[i];
+                    auto child_node = parse_node(child);
+                    if (child_node) { group->add_node(child_node); }
+                }
+            }
+            return group;
+        }
+
+        // Leaf node: geometry object
+        auto geom = make_geometry(node);
+        if (!geom) {
+            spdlog::warn("unknown or invalid geometry type: '{}'", type);
+            return nullptr;
+        }
+
+        auto obj = std::make_shared<objects::Object>(*geom);
+        obj->transform() = xf;
+        return obj;
+    }
+
+    // ── Camera parsing ──
+
+    auto parse_camera(const sol::table &t) -> Camera {
+        sol::optional<sol::table> pos_t =
+            t.get<sol::optional<sol::table>>("position");
+        sol::optional<sol::table> target_t =
+            t.get<sol::optional<sol::table>>("target");
+        sol::optional<sol::table> up_t = t.get<sol::optional<sol::table>>("up");
+
+        Vector3d pos = pos_t ? table_to_vec3(*pos_t) : Vector3d{0.0, 0.0, 5.0};
+        Vector3d target =
+            target_t ? table_to_vec3(*target_t) : Vector3d{0.0, 0.0, 0.0};
+        Vector3d up = up_t ? table_to_vec3(*up_t) : Vector3d{0.0, 1.0, 0.0};
+
+        return Camera(Camera::lookAt(Point(pos), Point(target), Point(up)));
+    }
+
+    // ── Core loader: table → SceneDescription ──
+
+    auto parse_scene_table(const sol::table &tbl)
+        -> std::expected<SceneDescription, std::string> {
+        SceneDescription desc;
+
+        // Parse render settings
+        sol::optional<sol::table> render =
+            tbl.get<sol::optional<sol::table>>("render");
+        if (render) {
+            desc.width = render->get_or<size_t>("width", 800);
+            desc.height = render->get_or<size_t>("height", 600);
+            desc.output_path =
+                render->get_or<std::string>("output", "output.ppm");
+            desc.accelerator =
+                render->get_or<std::string>("accelerator", "bvh");
+        }
+
+        // Parse camera
+        sol::optional<sol::table> camera =
+            tbl.get<sol::optional<sol::table>>("camera");
+        if (camera) { desc.camera = parse_camera(*camera); }
+
+        // Parse scene graph
+        sol::optional<sol::table> scene =
+            tbl.get<sol::optional<sol::table>>("scene");
+        if (!scene) {
+            return std::unexpected("scene table missing 'scene' key");
+        }
+
+        // If there's only one top-level node, use it directly.
+        // Otherwise, wrap in a group.
+        size_t count = scene->size();
+        if (count == 0) {
+            return std::unexpected("scene table 'scene' is empty");
+        }
+        if (count == 1) {
+            sol::table node = (*scene)[1];
+            desc.root = parse_node(node);
+        } else {
+            auto group = objects::InternalSceneNode::create();
+            for (size_t i = 1; i <= count; ++i) {
+                sol::table node = (*scene)[i];
+                auto child = parse_node(node);
+                if (child) { group->add_node(child); }
+            }
+            desc.root = group;
+        }
+
+        if (!desc.root) {
+            return std::unexpected("failed to construct any scene nodes");
+        }
+
+        return desc;
+    }
+
+} // anonymous namespace
+
+// ── Public API ──
+
+auto load_scene(const std::filesystem::path &script_path)
+    -> std::expected<SceneDescription, std::string> {
+    if (!std::filesystem::exists(script_path)) {
+        return std::unexpected(
+            std::format("scene file not found: {}", script_path.string()));
+    }
+
+    sol::state lua;
+    lua.open_libraries(sol::lib::base,
+                       sol::lib::string,
+                       sol::lib::math,
+                       sol::lib::table,
+                       sol::lib::io,
+                       sol::lib::os);
+
+    load_bindings(lua);
+
+    // Set the script's directory as a search path so require() works
+    auto parent = script_path.parent_path();
+    if (!parent.empty()) {
+        lua["package"]["path"] =
+            parent.string() + "/?.lua;"
+            + lua["package"]["path"].get_or<std::string>("");
+    }
+
+    auto result =
+        lua.safe_script_file(script_path.string(), sol::script_pass_on_error);
+    if (!result.valid()) {
+        sol::error err = result;
+        return std::unexpected(std::format("Lua error: {}", err.what()));
+    }
+
+    // The script must return a table
+    sol::object retval = result;
+    if (retval.get_type() != sol::type::table) {
+        return std::unexpected("scene script must return a table");
+    }
+
+    return parse_scene_table(retval.as<sol::table>());
+}
+
+auto load_scene_from_string(const std::string &lua_source)
+    -> std::expected<SceneDescription, std::string> {
+    sol::state lua;
+    lua.open_libraries(
+        sol::lib::base, sol::lib::string, sol::lib::math, sol::lib::table);
+
+    load_bindings(lua);
+
+    auto result = lua.safe_script(lua_source, sol::script_pass_on_error);
+    if (!result.valid()) {
+        sol::error err = result;
+        return std::unexpected(std::format("Lua error: {}", err.what()));
+    }
+
+    sol::object retval = result;
+    if (retval.get_type() != sol::type::table) {
+        return std::unexpected("scene script must return a table");
+    }
+
+    return parse_scene_table(retval.as<sol::table>());
+}
+
+auto render_scene(const SceneDescription &desc)
+    -> std::expected<Image, std::string> {
+    if (!desc.root) { return std::unexpected("scene has no root node"); }
+
+    // Build accelerator
+    std::unique_ptr<accel::SceneAccelerator> accel;
+    if (desc.accelerator == "linear") {
+        accel = std::make_unique<accel::LinearAccelerator>();
+    } else {
+        accel = std::make_unique<accel::BVHAccelerator>();
+    }
+    accel->build(*desc.root);
+
+    spdlog::info("rendering {}x{} with {} accelerator ({} primitives)",
+                 desc.width,
+                 desc.height,
+                 desc.accelerator,
+                 accel->primitives().size());
+
+    Image img = desc.camera.render(desc.width, desc.height, *accel);
+    return img;
+}
+
+} // namespace art::lua

--- a/src/lua/scene_serializer.cpp
+++ b/src/lua/scene_serializer.cpp
@@ -1,0 +1,337 @@
+/// @file src/lua/scene_serializer.cpp
+/// Serialize a SceneDescription to Lua table DSL (round-trip).
+
+#include "art/lua/scene_serializer.hpp"
+
+#include <cmath>
+#include <format>
+#include <sstream>
+#include <string>
+
+#include "art/Camera.hpp"
+#include "art/lua/scene_loader.hpp"
+#include "art/objects/InternalSceneNode.hpp"
+#include "art/objects/Object.hpp"
+#include "art/utils/AffineTransform.hpp"
+
+#include "art/geometry/Box.hpp"
+#include "art/geometry/Cylinder.hpp"
+#include "art/geometry/Disk.hpp"
+#include "art/geometry/MeshGeometry.hpp"
+#include "art/geometry/Plane.hpp"
+#include "art/geometry/Sphere.hpp"
+#include "art/geometry/Triangle.hpp"
+
+#include <zipper/transform/decompose.hpp>
+
+namespace art::lua {
+
+namespace {
+
+    // ── Formatting helpers ──
+
+    auto fmt_double(double v) -> std::string {
+        // Format with enough precision for round-trip but trim trailing zeros
+        auto s = std::format("{:.10g}", v);
+        return s;
+    }
+
+    auto fmt_vec3(const Vector3d &v) -> std::string {
+        return std::format("{{{}, {}, {}}}",
+                           fmt_double(v(0)),
+                           fmt_double(v(1)),
+                           fmt_double(v(2)));
+    }
+
+    auto indent(int depth) -> std::string {
+        return std::string(depth * 4, ' ');
+    }
+
+    // ── Transform serialization ──
+
+    auto is_identity(const utils::AffineTransform &xf) -> bool {
+        for (int r = 0; r < 4; ++r) {
+            for (int c = 0; c < 4; ++c) {
+                double expected = (r == c) ? 1.0 : 0.0;
+                if (std::abs(static_cast<double>(xf(r, c)) - expected)
+                    > 1e-12) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    auto serialize_transform(const utils::AffineTransform &xf, int depth)
+        -> std::string {
+        if (is_identity(xf)) { return ""; }
+
+        auto [t, r, s] = zipper::transform::trs_decompose(xf);
+
+        auto tv = t.vector();
+        auto sf = s.factors();
+
+        bool has_translate = std::abs(static_cast<double>(tv(0))) > 1e-12
+                             || std::abs(static_cast<double>(tv(1))) > 1e-12
+                             || std::abs(static_cast<double>(tv(2))) > 1e-12;
+
+        bool is_uniform_scale =
+            std::abs(static_cast<double>(sf(0)) - static_cast<double>(sf(1)))
+                < 1e-12
+            && std::abs(static_cast<double>(sf(1)) - static_cast<double>(sf(2)))
+                   < 1e-12;
+        bool has_scale = std::abs(static_cast<double>(sf(0)) - 1.0) > 1e-12
+                         || std::abs(static_cast<double>(sf(1)) - 1.0) > 1e-12
+                         || std::abs(static_cast<double>(sf(2)) - 1.0) > 1e-12;
+
+        // Check if rotation is identity
+        auto rm = r.matrix();
+        bool has_rotation = false;
+        for (int i = 0; i < 3 && !has_rotation; ++i) {
+            for (int j = 0; j < 3 && !has_rotation; ++j) {
+                double expected = (i == j) ? 1.0 : 0.0;
+                if (std::abs(static_cast<double>(rm(i, j)) - expected)
+                    > 1e-12) {
+                    has_rotation = true;
+                }
+            }
+        }
+
+        if (!has_translate && !has_rotation && !has_scale) { return ""; }
+
+        std::ostringstream out;
+        out << indent(depth) << "transform = {\n";
+
+        if (has_translate) {
+            Vector3d tvec{
+                static_cast<double>(tv(0)),
+                static_cast<double>(tv(1)),
+                static_cast<double>(tv(2)),
+            };
+            out << indent(depth + 1) << "translate = " << fmt_vec3(tvec)
+                << ",\n";
+        }
+
+        if (has_rotation) {
+            // Extract angle-axis from rotation matrix via Rodrigues' inverse
+            // trace(R) = 1 + 2*cos(angle)
+            double trace = static_cast<double>(rm(0, 0))
+                           + static_cast<double>(rm(1, 1))
+                           + static_cast<double>(rm(2, 2));
+            double cos_angle = (trace - 1.0) / 2.0;
+            cos_angle = std::clamp(cos_angle, -1.0, 1.0);
+            double angle = std::acos(cos_angle);
+
+            if (std::abs(angle) > 1e-12) {
+                // axis = [R(2,1)-R(1,2), R(0,2)-R(2,0), R(1,0)-R(0,1)] /
+                // (2*sin(angle))
+                double sin_angle = std::sin(angle);
+                Vector3d axis{
+                    (static_cast<double>(rm(2, 1))
+                     - static_cast<double>(rm(1, 2)))
+                        / (2.0 * sin_angle),
+                    (static_cast<double>(rm(0, 2))
+                     - static_cast<double>(rm(2, 0)))
+                        / (2.0 * sin_angle),
+                    (static_cast<double>(rm(1, 0))
+                     - static_cast<double>(rm(0, 1)))
+                        / (2.0 * sin_angle),
+                };
+                out << indent(depth + 1)
+                    << "rotate = {angle = " << fmt_double(angle)
+                    << ", axis = " << fmt_vec3(axis) << "},\n";
+            }
+        }
+
+        if (has_scale) {
+            if (is_uniform_scale) {
+                out << indent(depth + 1)
+                    << "scale = " << fmt_double(static_cast<double>(sf(0)))
+                    << ",\n";
+            } else {
+                Vector3d svec{
+                    static_cast<double>(sf(0)),
+                    static_cast<double>(sf(1)),
+                    static_cast<double>(sf(2)),
+                };
+                out << indent(depth + 1) << "scale = " << fmt_vec3(svec)
+                    << ",\n";
+            }
+        }
+
+        out << indent(depth) << "},\n";
+        return out.str();
+    }
+
+    // ── Geometry serialization ──
+
+    auto serialize_geometry_fields(const geometry::Geometry &geom, int depth)
+        -> std::string {
+        std::ostringstream out;
+
+        if (dynamic_cast<const geometry::Sphere *>(&geom)) {
+            out << indent(depth) << "type = \"sphere\",\n";
+        } else if (const auto *box =
+                       dynamic_cast<const geometry::Box *>(&geom)) {
+            out << indent(depth) << "type = \"box\",\n";
+            Vector3d mn = box->min();
+            Vector3d mx = box->max();
+            // Only emit min/max if they differ from the default
+            bool is_default = std::abs(mn(0) - (-0.5)) < 1e-12
+                              && std::abs(mn(1) - (-0.5)) < 1e-12
+                              && std::abs(mn(2) - (-0.5)) < 1e-12
+                              && std::abs(mx(0) - 0.5) < 1e-12
+                              && std::abs(mx(1) - 0.5) < 1e-12
+                              && std::abs(mx(2) - 0.5) < 1e-12;
+            if (!is_default) {
+                out << indent(depth) << "min = " << fmt_vec3(mn) << ",\n";
+                out << indent(depth) << "max = " << fmt_vec3(mx) << ",\n";
+            }
+        } else if (dynamic_cast<const geometry::Plane *>(&geom)) {
+            out << indent(depth) << "type = \"plane\",\n";
+        } else if (dynamic_cast<const geometry::Disk *>(&geom)) {
+            out << indent(depth) << "type = \"disk\",\n";
+        } else if (dynamic_cast<const geometry::Cylinder *>(&geom)) {
+            out << indent(depth) << "type = \"cylinder\",\n";
+        } else if (const auto *tri =
+                       dynamic_cast<const geometry::Triangle *>(&geom)) {
+            out << indent(depth) << "type = \"triangle\",\n";
+
+            const auto &verts = tri->vertices();
+            out << indent(depth) << "vertices = {" << fmt_vec3(verts[0]) << ", "
+                << fmt_vec3(verts[1]) << ", " << fmt_vec3(verts[2]) << "},\n";
+
+            if (tri->normals()) {
+                const auto &norms = *tri->normals();
+                out << indent(depth) << "normals = {" << fmt_vec3(norms[0])
+                    << ", " << fmt_vec3(norms[1]) << ", " << fmt_vec3(norms[2])
+                    << "},\n";
+            }
+        } else if (const auto *mesh =
+                       dynamic_cast<const geometry::MeshGeometry *>(&geom)) {
+            out << indent(depth) << "type = \"mesh\",\n";
+            out << indent(depth) << "-- mesh with " << mesh->triangle_count()
+                << " triangles (data omitted)\n";
+        } else {
+            out << indent(depth) << "type = \"unknown\",\n";
+        }
+
+        return out.str();
+    }
+
+    // ── Scene node serialization (recursive) ──
+
+    auto serialize_node(const objects::SceneNode &node, int depth)
+        -> std::string {
+        std::ostringstream out;
+
+        if (const auto *group =
+                dynamic_cast<const objects::InternalSceneNode *>(&node)) {
+            out << indent(depth) << "{\n";
+            out << indent(depth + 1) << "type = \"group\",\n";
+            out << serialize_transform(node.transform(), depth + 1);
+
+            const auto &children = group->children();
+            if (!children.empty()) {
+                out << indent(depth + 1) << "children = {\n";
+                for (const auto &child : children) {
+                    if (child) { out << serialize_node(*child, depth + 2); }
+                }
+                out << indent(depth + 1) << "},\n";
+            }
+            out << indent(depth) << "},\n";
+        } else if (const auto *obj =
+                       dynamic_cast<const objects::Object *>(&node)) {
+            out << indent(depth) << "{\n";
+            out << serialize_geometry_fields(obj->geometry(), depth + 1);
+            out << serialize_transform(node.transform(), depth + 1);
+            out << indent(depth) << "},\n";
+        }
+
+        return out.str();
+    }
+
+    // ── Camera serialization ──
+
+    auto serialize_camera(const Camera &cam, int depth) -> std::string {
+        std::ostringstream out;
+
+        // The camera stores an Isometry. We can extract eye position from
+        // the inverse transform's translation (camera-to-world), and derive
+        // target and up from the rotation columns.
+        auto cam_to_world = cam.transform().inverse();
+        auto tv = cam_to_world.translation();
+        Vector3d eye{
+            static_cast<double>(tv(0)),
+            static_cast<double>(tv(1)),
+            static_cast<double>(tv(2)),
+        };
+
+        // Camera looks along -Z in camera space, up is +Y
+        auto lin = cam_to_world.linear();
+        Vector3d forward{
+            -static_cast<double>(lin(0, 2)),
+            -static_cast<double>(lin(1, 2)),
+            -static_cast<double>(lin(2, 2)),
+        };
+        Vector3d up{
+            static_cast<double>(lin(0, 1)),
+            static_cast<double>(lin(1, 1)),
+            static_cast<double>(lin(2, 1)),
+        };
+        Vector3d target = (eye + forward).eval();
+
+        out << indent(depth) << "camera = {\n";
+        out << indent(depth + 1) << "position = " << fmt_vec3(eye) << ",\n";
+        out << indent(depth + 1) << "target = " << fmt_vec3(target) << ",\n";
+        out << indent(depth + 1) << "up = " << fmt_vec3(up) << ",\n";
+        out << indent(depth) << "},\n";
+
+        return out.str();
+    }
+
+} // anonymous namespace
+
+// ── Public API ──
+
+auto serialize_scene(const SceneDescription &desc) -> std::string {
+    std::ostringstream out;
+    out << "return {\n";
+
+    // Render settings
+    out << indent(1) << "render = {\n";
+    out << indent(2) << "width = " << desc.width << ",\n";
+    out << indent(2) << "height = " << desc.height << ",\n";
+    out << indent(2) << "output = \"" << desc.output_path << "\",\n";
+    out << indent(2) << "accelerator = \"" << desc.accelerator << "\",\n";
+    out << indent(1) << "},\n";
+
+    // Camera
+    out << serialize_camera(desc.camera, 1);
+
+    // Scene graph
+    out << indent(1) << "scene = {\n";
+    if (desc.root) {
+        // If root is a group, emit its children directly at top level
+        if (const auto *group =
+                dynamic_cast<const objects::InternalSceneNode *>(
+                    desc.root.get())) {
+            // Only flatten if the group itself has identity transform
+            if (is_identity(group->transform())) {
+                for (const auto &child : group->children()) {
+                    if (child) { out << serialize_node(*child, 2); }
+                }
+            } else {
+                out << serialize_node(*desc.root, 2);
+            }
+        } else {
+            out << serialize_node(*desc.root, 2);
+        }
+    }
+    out << indent(1) << "},\n";
+
+    out << "}\n";
+    return out.str();
+}
+
+} // namespace art::lua

--- a/subprojects/lua.wrap
+++ b/subprojects/lua.wrap
@@ -1,0 +1,2 @@
+[wrap-redirect]
+filename = quiver/subprojects/lua.wrap

--- a/subprojects/sol2.wrap
+++ b/subprojects/sol2.wrap
@@ -1,0 +1,3 @@
+[wrap-git]
+url = https://github.com/ThePhD/sol2.git
+revision = v3.5.0

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -6,3 +6,11 @@ art_test_dep = declare_dependency(
 sources = ['test_point.cpp', 'test_rational.cpp', 'test_image.cpp', 'test_image_io.cpp', 'test_intersection.cpp', 'test_plane.cpp', 'test_disk.cpp', 'test_cylinder.cpp', 'test_triangle.cpp', 'test_mesh_geometry.cpp', 'test_accelerator.cpp']
 test_art = executable('test_art', sources, dependencies: [art_test_dep])
 test('art', test_art)
+
+if lua_enabled
+  lua_test_sources = ['test_scene_loader.cpp']
+  test_art_lua = executable('test_art_lua', lua_test_sources,
+    dependencies: [art_test_dep] + lua_deps,
+    cpp_args: lua_cpp_args)
+  test('art_lua', test_art_lua)
+endif

--- a/tests/test_scene_loader.cpp
+++ b/tests/test_scene_loader.cpp
@@ -1,0 +1,298 @@
+/// @file tests/test_scene_loader.cpp
+/// Tests for the Lua table DSL scene loader.
+
+#include <catch2/catch_all.hpp>
+
+#include "art/lua/scene_loader.hpp"
+#include "art/objects/InternalSceneNode.hpp"
+#include "art/objects/Object.hpp"
+
+using namespace art;
+
+TEST_CASE("load_scene_from_string: single sphere", "[lua][scene_loader]") {
+    auto result = lua::load_scene_from_string(R"lua(
+        return {
+            render = {
+                width = 100,
+                height = 100,
+                output = "test.ppm",
+            },
+            camera = {
+                position = {0, 0, 5},
+                target = {0, 0, 0},
+                up = {0, 1, 0},
+            },
+            scene = {
+                { type = "sphere" },
+            },
+        }
+    )lua");
+
+    REQUIRE(result.has_value());
+    auto &desc = *result;
+    CHECK(desc.width == 100);
+    CHECK(desc.height == 100);
+    CHECK(desc.output_path == "test.ppm");
+    REQUIRE(desc.root != nullptr);
+}
+
+TEST_CASE("load_scene_from_string: multiple objects", "[lua][scene_loader]") {
+    auto result = lua::load_scene_from_string(R"lua(
+        return {
+            camera = {
+                position = {0, 0, 5},
+                target = {0, 0, 0},
+                up = {0, 1, 0},
+            },
+            scene = {
+                { type = "sphere" },
+                { type = "box" },
+                { type = "plane" },
+            },
+        }
+    )lua");
+
+    REQUIRE(result.has_value());
+    auto &desc = *result;
+
+    // Multiple top-level objects get wrapped in a group
+    auto group =
+        std::dynamic_pointer_cast<objects::InternalSceneNode>(desc.root);
+    REQUIRE(group != nullptr);
+    CHECK(group->children().size() == 3);
+}
+
+TEST_CASE("load_scene_from_string: transform parsing", "[lua][scene_loader]") {
+    auto result = lua::load_scene_from_string(R"lua(
+        return {
+            camera = {
+                position = {0, 0, 5},
+                target = {0, 0, 0},
+                up = {0, 1, 0},
+            },
+            scene = {
+                {
+                    type = "sphere",
+                    transform = {
+                        translate = {1, 2, 3},
+                    },
+                },
+            },
+        }
+    )lua");
+
+    REQUIRE(result.has_value());
+    REQUIRE(result->root != nullptr);
+}
+
+TEST_CASE("load_scene_from_string: group with children",
+          "[lua][scene_loader]") {
+    auto result = lua::load_scene_from_string(R"lua(
+        return {
+            camera = {
+                position = {0, 0, 5},
+                target = {0, 0, 0},
+                up = {0, 1, 0},
+            },
+            scene = {
+                {
+                    type = "group",
+                    transform = { translate = {0, 1, 0} },
+                    children = {
+                        { type = "sphere" },
+                        { type = "box" },
+                    },
+                },
+            },
+        }
+    )lua");
+
+    REQUIRE(result.has_value());
+    auto group =
+        std::dynamic_pointer_cast<objects::InternalSceneNode>(result->root);
+    REQUIRE(group != nullptr);
+    CHECK(group->children().size() == 2);
+}
+
+TEST_CASE("load_scene_from_string: all geometry types", "[lua][scene_loader]") {
+    auto result = lua::load_scene_from_string(R"lua(
+        return {
+            camera = {
+                position = {0, 0, 5},
+                target = {0, 0, 0},
+                up = {0, 1, 0},
+            },
+            scene = {
+                { type = "sphere" },
+                { type = "box" },
+                { type = "box", min = {-1, -1, -1}, max = {1, 1, 1} },
+                { type = "plane" },
+                { type = "disk" },
+                { type = "cylinder" },
+                { type = "triangle", vertices = {{0,0,0}, {1,0,0}, {0,1,0}} },
+                { type = "cube_mesh" },
+            },
+        }
+    )lua");
+
+    REQUIRE(result.has_value());
+    auto group =
+        std::dynamic_pointer_cast<objects::InternalSceneNode>(result->root);
+    REQUIRE(group != nullptr);
+    CHECK(group->children().size() == 8);
+}
+
+TEST_CASE("load_scene_from_string: inline mesh", "[lua][scene_loader]") {
+    auto result = lua::load_scene_from_string(R"lua(
+        return {
+            camera = {
+                position = {0, 0, 5},
+                target = {0, 0, 0},
+                up = {0, 1, 0},
+            },
+            scene = {
+                {
+                    type = "mesh",
+                    vertices = {
+                        {0, 0, 0},
+                        {1, 0, 0},
+                        {0, 1, 0},
+                        {1, 1, 0},
+                    },
+                    triangles = {
+                        {0, 1, 2},
+                        {1, 3, 2},
+                    },
+                },
+            },
+        }
+    )lua");
+
+    REQUIRE(result.has_value());
+    REQUIRE(result->root != nullptr);
+}
+
+TEST_CASE("load_scene_from_string: render defaults", "[lua][scene_loader]") {
+    auto result = lua::load_scene_from_string(R"lua(
+        return {
+            camera = {
+                position = {0, 0, 5},
+                target = {0, 0, 0},
+                up = {0, 1, 0},
+            },
+            scene = {
+                { type = "sphere" },
+            },
+        }
+    )lua");
+
+    REQUIRE(result.has_value());
+    CHECK(result->width == 800);
+    CHECK(result->height == 600);
+    CHECK(result->output_path == "output.ppm");
+    CHECK(result->accelerator == "bvh");
+}
+
+TEST_CASE("load_scene_from_string: missing scene key", "[lua][scene_loader]") {
+    auto result = lua::load_scene_from_string(R"lua(
+        return {
+            camera = {
+                position = {0, 0, 5},
+                target = {0, 0, 0},
+                up = {0, 1, 0},
+            },
+        }
+    )lua");
+
+    REQUIRE(!result.has_value());
+    CHECK(result.error().find("scene") != std::string::npos);
+}
+
+TEST_CASE("load_scene_from_string: Lua syntax error", "[lua][scene_loader]") {
+    auto result = lua::load_scene_from_string("this is not valid lua }{}{");
+
+    REQUIRE(!result.has_value());
+    CHECK(result.error().find("Lua error") != std::string::npos);
+}
+
+TEST_CASE("load_scene_from_string: script returns non-table",
+          "[lua][scene_loader]") {
+    auto result = lua::load_scene_from_string(R"lua(
+        return 42
+    )lua");
+
+    REQUIRE(!result.has_value());
+    CHECK(result.error().find("table") != std::string::npos);
+}
+
+TEST_CASE("load_scene_from_string: accelerator selection",
+          "[lua][scene_loader]") {
+    auto result = lua::load_scene_from_string(R"lua(
+        return {
+            render = { accelerator = "linear" },
+            camera = {
+                position = {0, 0, 5},
+                target = {0, 0, 0},
+                up = {0, 1, 0},
+            },
+            scene = {
+                { type = "sphere" },
+            },
+        }
+    )lua");
+
+    REQUIRE(result.has_value());
+    CHECK(result->accelerator == "linear");
+}
+
+TEST_CASE("render_scene: basic render produces image", "[lua][scene_loader]") {
+    auto desc_result = lua::load_scene_from_string(R"lua(
+        return {
+            render = {
+                width = 10,
+                height = 10,
+            },
+            camera = {
+                position = {0, 0, 5},
+                target = {0, 0, 0},
+                up = {0, 1, 0},
+            },
+            scene = {
+                { type = "sphere" },
+            },
+        }
+    )lua");
+
+    REQUIRE(desc_result.has_value());
+
+    auto img_result = lua::render_scene(*desc_result);
+    REQUIRE(img_result.has_value());
+    CHECK(img_result->width() == 10);
+    CHECK(img_result->height() == 10);
+}
+
+TEST_CASE("load_scene_from_string: transform with scale + rotate + translate",
+          "[lua][scene_loader]") {
+    auto result = lua::load_scene_from_string(R"lua(
+        return {
+            camera = {
+                position = {0, 0, 5},
+                target = {0, 0, 0},
+                up = {0, 1, 0},
+            },
+            scene = {
+                {
+                    type = "sphere",
+                    transform = {
+                        translate = {1, 0, 0},
+                        rotate = {angle = 1.57, axis = {0, 1, 0}},
+                        scale = {2, 2, 2},
+                    },
+                },
+            },
+        }
+    )lua");
+
+    REQUIRE(result.has_value());
+    REQUIRE(result->root != nullptr);
+}

--- a/tests/test_scene_loader.cpp
+++ b/tests/test_scene_loader.cpp
@@ -1,9 +1,10 @@
 /// @file tests/test_scene_loader.cpp
-/// Tests for the Lua table DSL scene loader.
+/// Tests for the Lua table DSL scene loader and serializer.
 
 #include <catch2/catch_all.hpp>
 
 #include "art/lua/scene_loader.hpp"
+#include "art/lua/scene_serializer.hpp"
 #include "art/objects/InternalSceneNode.hpp"
 #include "art/objects/Object.hpp"
 
@@ -295,4 +296,330 @@ TEST_CASE("load_scene_from_string: transform with scale + rotate + translate",
 
     REQUIRE(result.has_value());
     REQUIRE(result->root != nullptr);
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// Serializer tests
+// ═══════════════════════════════════════════════════════════════════════
+
+TEST_CASE("serialize_scene: single sphere round-trip", "[lua][serializer]") {
+    auto original = lua::load_scene_from_string(R"lua(
+        return {
+            render = { width = 320, height = 240, output = "out.ppm" },
+            camera = {
+                position = {0, 0, 5},
+                target = {0, 0, 0},
+                up = {0, 1, 0},
+            },
+            scene = {
+                { type = "sphere" },
+            },
+        }
+    )lua");
+    REQUIRE(original.has_value());
+
+    auto lua_str = lua::serialize_scene(*original);
+    REQUIRE(!lua_str.empty());
+
+    // Re-load from serialized output
+    auto reloaded = lua::load_scene_from_string(lua_str);
+    REQUIRE(reloaded.has_value());
+
+    CHECK(reloaded->width == 320);
+    CHECK(reloaded->height == 240);
+    CHECK(reloaded->output_path == "out.ppm");
+    REQUIRE(reloaded->root != nullptr);
+}
+
+TEST_CASE("serialize_scene: multiple geometry types round-trip",
+          "[lua][serializer]") {
+    auto original = lua::load_scene_from_string(R"lua(
+        return {
+            camera = {
+                position = {0, 0, 5},
+                target = {0, 0, 0},
+                up = {0, 1, 0},
+            },
+            scene = {
+                { type = "sphere" },
+                { type = "box" },
+                { type = "plane" },
+                { type = "disk" },
+                { type = "cylinder" },
+            },
+        }
+    )lua");
+    REQUIRE(original.has_value());
+
+    auto lua_str = lua::serialize_scene(*original);
+    auto reloaded = lua::load_scene_from_string(lua_str);
+    REQUIRE(reloaded.has_value());
+
+    auto group =
+        std::dynamic_pointer_cast<objects::InternalSceneNode>(reloaded->root);
+    REQUIRE(group != nullptr);
+    CHECK(group->children().size() == 5);
+}
+
+TEST_CASE("serialize_scene: box with custom bounds round-trip",
+          "[lua][serializer]") {
+    auto original = lua::load_scene_from_string(R"lua(
+        return {
+            camera = {
+                position = {0, 0, 5},
+                target = {0, 0, 0},
+                up = {0, 1, 0},
+            },
+            scene = {
+                { type = "box", min = {-2, -3, -4}, max = {2, 3, 4} },
+            },
+        }
+    )lua");
+    REQUIRE(original.has_value());
+
+    auto lua_str = lua::serialize_scene(*original);
+
+    // The serialized string should contain the custom bounds
+    CHECK(lua_str.find("min") != std::string::npos);
+    CHECK(lua_str.find("max") != std::string::npos);
+
+    auto reloaded = lua::load_scene_from_string(lua_str);
+    REQUIRE(reloaded.has_value());
+    REQUIRE(reloaded->root != nullptr);
+}
+
+TEST_CASE("serialize_scene: triangle round-trip", "[lua][serializer]") {
+    auto original = lua::load_scene_from_string(R"lua(
+        return {
+            camera = {
+                position = {0, 0, 5},
+                target = {0, 0, 0},
+                up = {0, 1, 0},
+            },
+            scene = {
+                { type = "triangle", vertices = {{0,0,0}, {1,0,0}, {0,1,0}} },
+            },
+        }
+    )lua");
+    REQUIRE(original.has_value());
+
+    auto lua_str = lua::serialize_scene(*original);
+
+    CHECK(lua_str.find("triangle") != std::string::npos);
+    CHECK(lua_str.find("vertices") != std::string::npos);
+
+    auto reloaded = lua::load_scene_from_string(lua_str);
+    REQUIRE(reloaded.has_value());
+    REQUIRE(reloaded->root != nullptr);
+}
+
+TEST_CASE("serialize_scene: group with children round-trip",
+          "[lua][serializer]") {
+    // A group with a non-identity transform should preserve the group
+    // structure in the serialized output (identity groups are flattened).
+    auto original = lua::load_scene_from_string(R"lua(
+        return {
+            camera = {
+                position = {0, 0, 5},
+                target = {0, 0, 0},
+                up = {0, 1, 0},
+            },
+            scene = {
+                {
+                    type = "group",
+                    transform = { translate = {1, 0, 0} },
+                    children = {
+                        { type = "sphere" },
+                        { type = "box" },
+                    },
+                },
+            },
+        }
+    )lua");
+    REQUIRE(original.has_value());
+
+    auto lua_str = lua::serialize_scene(*original);
+
+    CHECK(lua_str.find("group") != std::string::npos);
+    CHECK(lua_str.find("children") != std::string::npos);
+
+    auto reloaded = lua::load_scene_from_string(lua_str);
+    REQUIRE(reloaded.has_value());
+    REQUIRE(reloaded->root != nullptr);
+}
+
+TEST_CASE("serialize_scene: transform with translation round-trip",
+          "[lua][serializer]") {
+    auto original = lua::load_scene_from_string(R"lua(
+        return {
+            camera = {
+                position = {0, 0, 5},
+                target = {0, 0, 0},
+                up = {0, 1, 0},
+            },
+            scene = {
+                {
+                    type = "sphere",
+                    transform = {
+                        translate = {3, 4, 5},
+                    },
+                },
+            },
+        }
+    )lua");
+    REQUIRE(original.has_value());
+
+    auto lua_str = lua::serialize_scene(*original);
+
+    CHECK(lua_str.find("translate") != std::string::npos);
+    CHECK(lua_str.find("3") != std::string::npos);
+    CHECK(lua_str.find("4") != std::string::npos);
+    CHECK(lua_str.find("5") != std::string::npos);
+
+    auto reloaded = lua::load_scene_from_string(lua_str);
+    REQUIRE(reloaded.has_value());
+    REQUIRE(reloaded->root != nullptr);
+}
+
+TEST_CASE("serialize_scene: transform with uniform scale round-trip",
+          "[lua][serializer]") {
+    auto original = lua::load_scene_from_string(R"lua(
+        return {
+            camera = {
+                position = {0, 0, 5},
+                target = {0, 0, 0},
+                up = {0, 1, 0},
+            },
+            scene = {
+                {
+                    type = "sphere",
+                    transform = {
+                        scale = 2.5,
+                    },
+                },
+            },
+        }
+    )lua");
+    REQUIRE(original.has_value());
+
+    auto lua_str = lua::serialize_scene(*original);
+
+    CHECK(lua_str.find("scale") != std::string::npos);
+
+    auto reloaded = lua::load_scene_from_string(lua_str);
+    REQUIRE(reloaded.has_value());
+    REQUIRE(reloaded->root != nullptr);
+}
+
+TEST_CASE("serialize_scene: camera position round-trip", "[lua][serializer]") {
+    auto original = lua::load_scene_from_string(R"lua(
+        return {
+            camera = {
+                position = {1, 2, 3},
+                target = {0, 0, 0},
+                up = {0, 1, 0},
+            },
+            scene = {
+                { type = "sphere" },
+            },
+        }
+    )lua");
+    REQUIRE(original.has_value());
+
+    auto lua_str = lua::serialize_scene(*original);
+
+    CHECK(lua_str.find("camera") != std::string::npos);
+    CHECK(lua_str.find("position") != std::string::npos);
+    CHECK(lua_str.find("target") != std::string::npos);
+    CHECK(lua_str.find("up") != std::string::npos);
+
+    auto reloaded = lua::load_scene_from_string(lua_str);
+    REQUIRE(reloaded.has_value());
+    REQUIRE(reloaded->root != nullptr);
+}
+
+TEST_CASE("serialize_scene: accelerator setting preserved",
+          "[lua][serializer]") {
+    auto original = lua::load_scene_from_string(R"lua(
+        return {
+            render = { accelerator = "linear" },
+            camera = {
+                position = {0, 0, 5},
+                target = {0, 0, 0},
+                up = {0, 1, 0},
+            },
+            scene = {
+                { type = "sphere" },
+            },
+        }
+    )lua");
+    REQUIRE(original.has_value());
+
+    auto lua_str = lua::serialize_scene(*original);
+    auto reloaded = lua::load_scene_from_string(lua_str);
+    REQUIRE(reloaded.has_value());
+
+    CHECK(reloaded->accelerator == "linear");
+}
+
+TEST_CASE("serialize_scene: identity transform omitted", "[lua][serializer]") {
+    auto original = lua::load_scene_from_string(R"lua(
+        return {
+            camera = {
+                position = {0, 0, 5},
+                target = {0, 0, 0},
+                up = {0, 1, 0},
+            },
+            scene = {
+                { type = "sphere" },
+            },
+        }
+    )lua");
+    REQUIRE(original.has_value());
+
+    auto lua_str = lua::serialize_scene(*original);
+
+    // A sphere with identity transform should NOT have a transform field
+    // (The "transform" substring should only appear in the render/camera
+    // context, not in the scene node)
+    auto scene_start = lua_str.find("scene");
+    REQUIRE(scene_start != std::string::npos);
+    auto scene_section = lua_str.substr(scene_start);
+    CHECK(scene_section.find("transform") == std::string::npos);
+}
+
+TEST_CASE("serialize_scene: nested groups round-trip", "[lua][serializer]") {
+    auto original = lua::load_scene_from_string(R"lua(
+        return {
+            camera = {
+                position = {0, 0, 5},
+                target = {0, 0, 0},
+                up = {0, 1, 0},
+            },
+            scene = {
+                {
+                    type = "group",
+                    transform = { translate = {1, 0, 0} },
+                    children = {
+                        {
+                            type = "group",
+                            transform = { translate = {0, 1, 0} },
+                            children = {
+                                { type = "sphere" },
+                            },
+                        },
+                        { type = "box" },
+                    },
+                },
+            },
+        }
+    )lua");
+    REQUIRE(original.has_value());
+
+    auto lua_str = lua::serialize_scene(*original);
+    auto reloaded = lua::load_scene_from_string(lua_str);
+    REQUIRE(reloaded.has_value());
+    REQUIRE(reloaded->root != nullptr);
+
+    // Should be parseable: that's the main round-trip guarantee
 }

--- a/tools/lua_to_pbrt.lua
+++ b/tools/lua_to_pbrt.lua
@@ -1,0 +1,373 @@
+#!/usr/bin/env lua
+--- lua_to_pbrt — Convert ART Lua scene tables to PBRT v3 format.
+---
+--- Can be used as a module:
+---   local l2p = require("lua_to_pbrt")
+---   local pbrt_source = l2p.to_pbrt(scene_table)
+---   l2p.convert_file("input.lua", "output.pbrt")
+---
+--- Or as a CLI script:
+---   lua lua_to_pbrt.lua input.lua [output.pbrt]
+---
+--- Shape mapping (ART -> PBRT):
+---   sphere        -> Shape "sphere"
+---   disk          -> Shape "disk"
+---   cylinder      -> Shape "cylinder"
+---   box           -> Shape "trianglemesh" (tessellated to 12 triangles)
+---   plane         -> Shape "disk" (large radius=1000)
+---   triangle      -> Shape "trianglemesh" (1 triangle)
+---   mesh          -> Shape "trianglemesh"
+---   group         -> AttributeBegin / AttributeEnd
+---
+--- Transform mapping (ART -> PBRT):
+---   translate     -> Translate x y z
+---   rotate        -> Rotate degrees x y z
+---   scale         -> Scale x y z
+---   matrix        -> ConcatTransform [16 values]
+
+local M = {}
+
+-- ════════════════════════════════════════════════════════════════════
+-- Utilities
+-- ════════════════════════════════════════════════════════════════════
+
+local function fmt_num(v)
+    if v == math.floor(v) and math.abs(v) < 1e15 then
+        return string.format("%g", v)
+    end
+    return string.format("%.10g", v)
+end
+
+local function indent(depth)
+    return string.rep("  ", depth)
+end
+
+-- ════════════════════════════════════════════════════════════════════
+-- Transform emission
+-- ════════════════════════════════════════════════════════════════════
+
+--- Emit PBRT transform directives for a transform table.
+--- Returns a list of lines (without trailing newline).
+local function emit_transform(xf, depth)
+    if not xf then return {} end
+    local lines = {}
+    local pfx = indent(depth)
+
+    -- PBRT applies transforms in reverse order of specification,
+    -- so we emit in T, R, S order (same as ART's composition: T * R * S).
+    if xf.translate then
+        local t = xf.translate
+        lines[#lines + 1] = pfx .. string.format("Translate %s %s %s",
+            fmt_num(t[1]), fmt_num(t[2]), fmt_num(t[3]))
+    end
+
+    if xf.rotate then
+        local r = xf.rotate
+        local angle_deg = math.deg(r.angle)
+        local a = r.axis
+        lines[#lines + 1] = pfx .. string.format("Rotate %s %s %s %s",
+            fmt_num(angle_deg), fmt_num(a[1]), fmt_num(a[2]), fmt_num(a[3]))
+    end
+
+    if xf.scale then
+        if type(xf.scale) == "number" then
+            local s = xf.scale
+            lines[#lines + 1] = pfx .. string.format("Scale %s %s %s",
+                fmt_num(s), fmt_num(s), fmt_num(s))
+        else
+            local s = xf.scale
+            lines[#lines + 1] = pfx .. string.format("Scale %s %s %s",
+                fmt_num(s[1]), fmt_num(s[2]), fmt_num(s[3]))
+        end
+    end
+
+    if xf.matrix then
+        local parts = {}
+        for _, v in ipairs(xf.matrix) do
+            parts[#parts + 1] = fmt_num(v)
+        end
+        lines[#lines + 1] = pfx .. "ConcatTransform [" .. table.concat(parts, " ") .. "]"
+    end
+
+    return lines
+end
+
+-- ════════════════════════════════════════════════════════════════════
+-- Shape emission
+-- ════════════════════════════════════════════════════════════════════
+
+--- Emit a flat number array as a PBRT bracket list.
+local function bracket_array(values)
+    local parts = {}
+    for _, v in ipairs(values) do
+        parts[#parts + 1] = fmt_num(v)
+    end
+    return "[ " .. table.concat(parts, " ") .. " ]"
+end
+
+--- Emit a flat integer array as a PBRT bracket list.
+local function bracket_int_array(values)
+    local parts = {}
+    for _, v in ipairs(values) do
+        parts[#parts + 1] = string.format("%d", v)
+    end
+    return "[ " .. table.concat(parts, " ") .. " ]"
+end
+
+--- Box vertices and triangle indices (unit cube [-1,1]^3).
+local box_verts = {
+    {-1,-1,-1}, {1,-1,-1}, {1,1,-1}, {-1,1,-1},
+    {-1,-1, 1}, {1,-1, 1}, {1,1, 1}, {-1,1, 1},
+}
+local box_tris = {
+    {0,1,2}, {0,2,3},   -- front (-Z)
+    {4,6,5}, {4,7,6},   -- back (+Z)
+    {0,4,5}, {0,5,1},   -- bottom (-Y)
+    {2,6,7}, {2,7,3},   -- top (+Y)
+    {0,3,7}, {0,7,4},   -- left (-X)
+    {1,5,6}, {1,6,2},   -- right (+X)
+}
+
+local function emit_node(node, depth, lines)
+    if not node or not node.type then return end
+
+    local pfx = indent(depth)
+
+    -- Emit _comment as PBRT comment
+    if node._comment then
+        lines[#lines + 1] = pfx .. "# " .. node._comment
+    end
+
+    if node.type == "group" then
+        lines[#lines + 1] = pfx .. "AttributeBegin"
+        for _, line in ipairs(emit_transform(node.transform, depth + 1)) do
+            lines[#lines + 1] = line
+        end
+        if node.children then
+            for _, child in ipairs(node.children) do
+                emit_node(child, depth + 1, lines)
+            end
+        end
+        lines[#lines + 1] = pfx .. "AttributeEnd"
+
+    elseif node.type == "sphere" then
+        for _, line in ipairs(emit_transform(node.transform, depth)) do
+            lines[#lines + 1] = line
+        end
+        lines[#lines + 1] = pfx .. 'Shape "sphere"'
+
+    elseif node.type == "disk" then
+        for _, line in ipairs(emit_transform(node.transform, depth)) do
+            lines[#lines + 1] = line
+        end
+        lines[#lines + 1] = pfx .. 'Shape "disk"'
+
+    elseif node.type == "cylinder" then
+        for _, line in ipairs(emit_transform(node.transform, depth)) do
+            lines[#lines + 1] = line
+        end
+        lines[#lines + 1] = pfx .. 'Shape "cylinder"'
+
+    elseif node.type == "box" then
+        -- Tessellate to trianglemesh
+        for _, line in ipairs(emit_transform(node.transform, depth)) do
+            lines[#lines + 1] = line
+        end
+        local flat_P = {}
+        for _, v in ipairs(box_verts) do
+            flat_P[#flat_P + 1] = v[1]
+            flat_P[#flat_P + 1] = v[2]
+            flat_P[#flat_P + 1] = v[3]
+        end
+        local flat_idx = {}
+        for _, tri in ipairs(box_tris) do
+            flat_idx[#flat_idx + 1] = tri[1]
+            flat_idx[#flat_idx + 1] = tri[2]
+            flat_idx[#flat_idx + 1] = tri[3]
+        end
+        lines[#lines + 1] = pfx .. 'Shape "trianglemesh"'
+        lines[#lines + 1] = pfx .. '  "integer indices" ' .. bracket_int_array(flat_idx)
+        lines[#lines + 1] = pfx .. '  "point3 P" ' .. bracket_array(flat_P)
+
+    elseif node.type == "plane" then
+        -- Emit as large disk
+        for _, line in ipairs(emit_transform(node.transform, depth)) do
+            lines[#lines + 1] = line
+        end
+        lines[#lines + 1] = pfx .. 'Shape "disk" "float radius" [1000]'
+
+    elseif node.type == "triangle" then
+        for _, line in ipairs(emit_transform(node.transform, depth)) do
+            lines[#lines + 1] = line
+        end
+        if node.vertices and #node.vertices >= 3 then
+            local flat_P = {}
+            for i = 1, 3 do
+                local v = node.vertices[i]
+                flat_P[#flat_P + 1] = v[1]
+                flat_P[#flat_P + 1] = v[2]
+                flat_P[#flat_P + 1] = v[3]
+            end
+            lines[#lines + 1] = pfx .. 'Shape "trianglemesh"'
+            lines[#lines + 1] = pfx .. '  "integer indices" [ 0 1 2 ]'
+            lines[#lines + 1] = pfx .. '  "point3 P" ' .. bracket_array(flat_P)
+        else
+            lines[#lines + 1] = pfx .. '# triangle node missing vertices'
+        end
+
+    elseif node.type == "mesh" then
+        for _, line in ipairs(emit_transform(node.transform, depth)) do
+            lines[#lines + 1] = line
+        end
+        if node.vertices and node.triangles then
+            local flat_P = {}
+            for _, v in ipairs(node.vertices) do
+                flat_P[#flat_P + 1] = v[1]
+                flat_P[#flat_P + 1] = v[2]
+                flat_P[#flat_P + 1] = v[3]
+            end
+            local flat_idx = {}
+            for _, tri in ipairs(node.triangles) do
+                flat_idx[#flat_idx + 1] = tri[1]
+                flat_idx[#flat_idx + 1] = tri[2]
+                flat_idx[#flat_idx + 1] = tri[3]
+            end
+            lines[#lines + 1] = pfx .. 'Shape "trianglemesh"'
+            lines[#lines + 1] = pfx .. '  "integer indices" ' .. bracket_int_array(flat_idx)
+            lines[#lines + 1] = pfx .. '  "point3 P" ' .. bracket_array(flat_P)
+        else
+            lines[#lines + 1] = pfx .. '# mesh node missing vertices or triangles'
+        end
+
+    else
+        lines[#lines + 1] = pfx .. string.format('# unsupported ART type "%s"', node.type)
+    end
+end
+
+-- ════════════════════════════════════════════════════════════════════
+-- Module API
+-- ════════════════════════════════════════════════════════════════════
+
+--- Convert a scene table (ART Lua format) to PBRT source string.
+--- The scene_table should have the same structure as what parse_file() returns,
+--- or as what an ART Lua scene script returns (with render, camera, scene keys).
+--- @param scene_table table   Table with .render, .camera, .scene keys
+---                            (or a parse_file() result with .film_*, .camera_*, .scene)
+--- @return string             PBRT source
+function M.to_pbrt(scene_table)
+    local lines = {}
+    lines[#lines + 1] = "# Converted from ART Lua scene by lua_to_pbrt.lua"
+    lines[#lines + 1] = ""
+
+    -- Extract fields — support both direct scene tables and parse_file() results
+    local render = scene_table.render or {}
+    local width = render.width or scene_table.film_width or 800
+    local height = render.height or scene_table.film_height or 600
+    local filename = render.output or scene_table.film_filename or "output.ppm"
+
+    local camera = scene_table.camera or {}
+    local eye = camera.position or scene_table.camera_eye or {0, 0, 5}
+    local target = camera.target or scene_table.camera_target or {0, 0, 0}
+    local up = camera.up or scene_table.camera_up or {0, 1, 0}
+    local fov = camera.fov or scene_table.camera_fov or 45
+
+    local scene_nodes = scene_table.scene or {}
+
+    -- Emit TODO comments if present
+    if scene_table.todos and #scene_table.todos > 0 then
+        local seen = {}
+        for _, msg in ipairs(scene_table.todos) do
+            if not seen[msg] then
+                seen[msg] = true
+                lines[#lines + 1] = "# TODO: " .. msg
+            end
+        end
+        lines[#lines + 1] = ""
+    end
+
+    -- LookAt
+    lines[#lines + 1] = string.format("LookAt %s %s %s  %s %s %s  %s %s %s",
+        fmt_num(eye[1]), fmt_num(eye[2]), fmt_num(eye[3]),
+        fmt_num(target[1]), fmt_num(target[2]), fmt_num(target[3]),
+        fmt_num(up[1]), fmt_num(up[2]), fmt_num(up[3]))
+
+    -- Camera
+    lines[#lines + 1] = string.format('Camera "perspective" "float fov" [%s]', fmt_num(fov))
+
+    -- Film
+    lines[#lines + 1] = string.format(
+        'Film "image" "integer xresolution" [%d] "integer yresolution" [%d] "string filename" ["%s"]',
+        width, height, filename)
+
+    lines[#lines + 1] = ""
+    lines[#lines + 1] = "WorldBegin"
+
+    -- Scene nodes
+    for _, node in ipairs(scene_nodes) do
+        emit_node(node, 1, lines)
+    end
+
+    lines[#lines + 1] = "WorldEnd"
+    return table.concat(lines, "\n") .. "\n"
+end
+
+--- Load an ART Lua scene file and convert to PBRT.
+--- @param input_path  string   Path to input .lua file
+--- @param output_path string?  Path to output .pbrt file (nil = return string)
+--- @return string|nil          PBRT source if output_path is nil
+function M.convert_file(input_path, output_path)
+    -- Load and execute the Lua scene file to get the scene table
+    local chunk, err = loadfile(input_path)
+    if not chunk then
+        error(string.format("cannot load '%s': %s", input_path, err))
+    end
+    local ok, scene_table = pcall(chunk)
+    if not ok then
+        error(string.format("error executing '%s': %s", input_path, scene_table))
+    end
+    if type(scene_table) ~= "table" then
+        error(string.format("'%s' did not return a table", input_path))
+    end
+
+    local pbrt_output = M.to_pbrt(scene_table)
+
+    if output_path then
+        local out, werr = io.open(output_path, "w")
+        if not out then
+            error(string.format("cannot open '%s' for writing: %s", output_path, werr or "unknown"))
+        end
+        out:write(pbrt_output)
+        out:close()
+        io.stderr:write(string.format("Converted %s -> %s\n", input_path, output_path))
+        return nil
+    end
+
+    return pbrt_output
+end
+
+-- ════════════════════════════════════════════════════════════════════
+-- CLI entry point
+-- ════════════════════════════════════════════════════════════════════
+
+local function main()
+    if #arg < 1 then
+        io.stderr:write("Usage: lua lua_to_pbrt.lua <input.lua> [output.pbrt]\n")
+        os.exit(1)
+    end
+
+    local input_path = arg[1]
+    local output_path = arg[2]
+
+    if output_path then
+        M.convert_file(input_path, output_path)
+    else
+        local pbrt_output = M.convert_file(input_path)
+        io.write(pbrt_output)
+    end
+end
+
+if arg and arg[0] and arg[0]:match("lua_to_pbrt%.lua$") then
+    main()
+end
+
+return M

--- a/tools/meson.build
+++ b/tools/meson.build
@@ -1,0 +1,9 @@
+# Tools — standalone Lua scripts for PBRT <-> ART scene conversion.
+
+lua_tools = [
+    'pbrt_to_lua.lua',
+    'lua_to_pbrt.lua',
+    'validate_roundtrip.lua',
+]
+
+install_data(lua_tools, install_dir: get_option('datadir') / 'art' / 'tools')

--- a/tools/pbrt_to_lua.lua
+++ b/tools/pbrt_to_lua.lua
@@ -153,6 +153,9 @@ function Parser.new(tokens)
         base_dir = ".",
         -- Collected TODO comments for unsupported features
         todos = {},               -- list of strings
+        -- Warning dedup: key -> count
+        warning_counts = {},
+        warning_limit = 3,        -- max times to print same warning
     }, Parser)
 end
 
@@ -166,12 +169,24 @@ function Parser:advance()
     return t
 end
 
+--- Emit a warning with dedup: same key is printed at most `warning_limit` times.
+--- On the (limit+1)th occurrence, a "suppressing further" notice is emitted.
+function Parser:warn(key, msg)
+    local count = (self.warning_counts[key] or 0) + 1
+    self.warning_counts[key] = count
+    if count <= self.warning_limit then
+        io.stderr:write("warning: " .. msg .. "\n")
+    elseif count == self.warning_limit + 1 then
+        io.stderr:write(string.format("warning: suppressing further '%s' warnings (%d so far)\n", key, count))
+    end
+end
+
 function Parser:expect_type(typ)
     local t = self:advance()
     if not t or t.type ~= typ then
-        io.stderr:write(string.format(
-            "warning: expected %s, got %s at token %d\n",
-            typ, t and t.type or "EOF", self.pos - 1))
+        local got = t and t.type or "EOF"
+        self:warn("expected_" .. typ,
+            string.format("expected %s, got %s at token %d", typ, got, self.pos - 1))
         return nil
     end
     return t
@@ -816,7 +831,8 @@ function Parser:handle_ObjectInstance()
 
     local obj_nodes = self.objects[name]
     if not obj_nodes or #obj_nodes == 0 then
-        io.stderr:write(string.format("warning: ObjectInstance '%s' not found\n", name))
+        self:warn("ObjectInstance:" .. name,
+            string.format("ObjectInstance '%s' not found", name))
         return
     end
 
@@ -831,13 +847,45 @@ function Parser:handle_Include()
     if not path_tok then return end
 
     local filepath = self.base_dir .. "/" .. path_tok.value
-    local f = io.open(filepath, "r")
-    if not f then
-        io.stderr:write(string.format("warning: cannot open Include file: %s\n", filepath))
-        return
+    local content
+
+    if filepath:match("%.gz$") then
+        -- Check compressed file size before decompressing
+        local stat_handle = io.popen(string.format('stat -c%%s "%s" 2>/dev/null', filepath))
+        local file_size = stat_handle and tonumber(stat_handle:read("*a"))
+        if stat_handle then stat_handle:close() end
+
+        -- Skip very large compressed files (>10MB compressed likely means 100MB+ decompressed)
+        local max_gz_size = 10 * 1024 * 1024
+        if file_size and file_size > max_gz_size then
+            self:warn("Include:gz_large:" .. filepath,
+                string.format("skipping large gzipped Include (%d MB compressed): %s",
+                    math.floor(file_size / 1024 / 1024), path_tok.value))
+            self:add_todo(string.format("Include '%s' skipped (large gzipped file)", path_tok.value))
+            return
+        end
+
+        -- Decompress gzipped includes via gzip -dc
+        local handle = io.popen(string.format('gzip -dc "%s" 2>/dev/null', filepath))
+        if handle then
+            content = handle:read("*a")
+            handle:close()
+        end
+        if not content or #content == 0 then
+            self:warn("Include:" .. filepath,
+                string.format("cannot decompress Include file: %s", filepath))
+            return
+        end
+    else
+        local f = io.open(filepath, "r")
+        if not f then
+            self:warn("Include:" .. filepath,
+                string.format("cannot open Include file: %s", filepath))
+            return
+        end
+        content = f:read("*a")
+        f:close()
     end
-    local content = f:read("*a")
-    f:close()
 
     -- Tokenize and parse the included file
     local inc_tokens = tokenize(content)
@@ -1005,6 +1053,14 @@ function Parser:parse(source)
     self.tokens = tokenize(source)
     self.pos = 1
     self:parse_directives()
+    -- Print summary of suppressed warnings
+    for key, count in pairs(self.warning_counts) do
+        if count > self.warning_limit then
+            io.stderr:write(string.format(
+                "warning: '%s' occurred %d times total (%d suppressed)\n",
+                key, count, count - self.warning_limit))
+        end
+    end
 end
 
 -- ════════════════════════════════════════════════════════════════════

--- a/tools/pbrt_to_lua.lua
+++ b/tools/pbrt_to_lua.lua
@@ -1,0 +1,1286 @@
+#!/usr/bin/env lua
+--- pbrt_to_lua — Convert PBRT v3/v4 scene files to ART Lua table DSL.
+---
+--- Can be used as a module:
+---   local pbrt = require("pbrt_to_lua")
+---   local scene, todos = pbrt.parse_file("input.pbrt")
+---   local lua_source    = pbrt.to_lua(scene, todos)
+---   pbrt.convert_file("input.pbrt", "output.lua")
+---
+--- Or as a CLI script:
+---   lua pbrt_to_lua.lua input.pbrt [output.lua]
+---
+--- Supported PBRT directives:
+---   LookAt, Camera ("perspective"), Film ("image" / "rgb")
+---   WorldBegin / WorldEnd (v3; v4 ends at EOF)
+---   AttributeBegin / AttributeEnd
+---   TransformBegin / TransformEnd (v3)
+---   Translate, Rotate, Scale, Identity, ConcatTransform, Transform
+---   Shape ("sphere", "trianglemesh", "disk", "cylinder", "plymesh",
+---          "bilinearmesh", "loopsubdiv", "curve", "cone", "paraboloid",
+---          "hyperboloid")
+---   ObjectBegin / ObjectEnd, ObjectInstance
+---   Include, Import (v4)
+---
+--- Unsupported directives (Material, LightSource, Texture, Integrator,
+--- Sampler, etc.) are consumed gracefully and emitted as TODO comments.
+
+local M = {}
+
+-- ════════════════════════════════════════════════════════════════════
+-- Utilities
+-- ════════════════════════════════════════════════════════════════════
+
+local function deep_copy(orig)
+    if type(orig) ~= "table" then return orig end
+    local copy = {}
+    for k, v in pairs(orig) do
+        copy[k] = deep_copy(v)
+    end
+    return copy
+end
+
+-- ════════════════════════════════════════════════════════════════════
+-- Tokenizer
+-- ════════════════════════════════════════════════════════════════════
+
+--- Tokenize a PBRT source string.
+--- Handles: quoted strings, brackets, numbers (incl. .5 and 1e-3),
+--- identifiers, and bare true/false (v4 bool params).
+--- Comments (#) are stripped.
+local function tokenize(source)
+    local tokens = {}
+    local pos = 1
+    local len = #source
+
+    while pos <= len do
+        -- Skip whitespace
+        local ws = source:match("^%s+", pos)
+        if ws then pos = pos + #ws end
+        if pos > len then break end
+
+        local ch = source:sub(pos, pos)
+
+        -- Comment: skip to end of line
+        if ch == "#" then
+            local nl = source:find("\n", pos)
+            pos = nl and nl + 1 or len + 1
+
+        -- Quoted string
+        elseif ch == '"' then
+            local close = source:find('"', pos + 1)
+            if not close then
+                io.stderr:write("warning: unterminated string at position " .. pos .. "\n")
+                break
+            end
+            tokens[#tokens + 1] = { type = "string", value = source:sub(pos + 1, close - 1) }
+            pos = close + 1
+
+        -- Open/close bracket
+        elseif ch == "[" then
+            tokens[#tokens + 1] = { type = "open_bracket" }
+            pos = pos + 1
+
+        elseif ch == "]" then
+            tokens[#tokens + 1] = { type = "close_bracket" }
+            pos = pos + 1
+
+        -- Number (including negative, decimal, scientific, leading-dot like .5)
+        else
+            local num = source:match("^%-?%d*%.?%d+[eE][%-+]?%d+", pos)
+                      or source:match("^%-?%d*%.%d+", pos)
+                      or source:match("^%-?%d+", pos)
+            if num then
+                tokens[#tokens + 1] = { type = "number", value = tonumber(num) }
+                pos = pos + #num
+            else
+                -- Identifier / directive / bare true/false
+                local id = source:match("^[A-Za-z_][A-Za-z0-9_]*", pos)
+                if id then
+                    -- v4 uses bare true/false in bracket arrays
+                    if id == "true" then
+                        tokens[#tokens + 1] = { type = "bool", value = true }
+                    elseif id == "false" then
+                        tokens[#tokens + 1] = { type = "bool", value = false }
+                    else
+                        tokens[#tokens + 1] = { type = "identifier", value = id }
+                    end
+                    pos = pos + #id
+                else
+                    -- Skip unknown character
+                    pos = pos + 1
+                end
+            end
+        end
+    end
+
+    return tokens
+end
+
+M.tokenize = tokenize
+
+-- ════════════════════════════════════════════════════════════════════
+-- Parser state
+-- ════════════════════════════════════════════════════════════════════
+
+local Parser = {}
+Parser.__index = Parser
+
+function Parser.new(tokens)
+    return setmetatable({
+        tokens = tokens,
+        pos = 1,
+        -- Camera
+        camera_eye = nil,
+        camera_target = nil,
+        camera_up = nil,
+        camera_fov = 45,
+        camera_type = "perspective",
+        -- Film
+        film_width = 800,
+        film_height = 600,
+        film_filename = "output.ppm",
+        -- Transform stack (each entry is a list of transform ops)
+        transform_stack = {},
+        current_transforms = {}, -- list of {type, ...} ops
+        -- Scene nodes
+        scene = {},               -- top-level scene array
+        node_stack = {},          -- stack for group nesting
+        -- Named objects
+        objects = {},             -- name -> node array
+        current_object_name = nil,
+        -- Base directory for Include / Import
+        base_dir = ".",
+        -- Collected TODO comments for unsupported features
+        todos = {},               -- list of strings
+    }, Parser)
+end
+
+function Parser:peek()
+    return self.tokens[self.pos]
+end
+
+function Parser:advance()
+    local t = self.tokens[self.pos]
+    self.pos = self.pos + 1
+    return t
+end
+
+function Parser:expect_type(typ)
+    local t = self:advance()
+    if not t or t.type ~= typ then
+        io.stderr:write(string.format(
+            "warning: expected %s, got %s at token %d\n",
+            typ, t and t.type or "EOF", self.pos - 1))
+        return nil
+    end
+    return t
+end
+
+--- Read N numbers from the token stream.
+function Parser:read_numbers(n)
+    local nums = {}
+    for i = 1, n do
+        local t = self:advance()
+        if t and t.type == "number" then
+            nums[i] = t.value
+        else
+            io.stderr:write(string.format(
+                "warning: expected number %d/%d, got %s\n",
+                i, n, t and t.type or "EOF"))
+            nums[i] = 0
+        end
+    end
+    return nums
+end
+
+--- Read a bracketed array: [ n1 n2 ... ] or [ "string" ] or [ true/false ]
+--- Returns a list of numbers, strings, or booleans.
+function Parser:read_bracket_array()
+    local t = self:peek()
+    if not t or t.type ~= "open_bracket" then return nil end
+    self:advance() -- consume [
+
+    local values = {}
+    while true do
+        t = self:peek()
+        if not t or t.type == "close_bracket" then break end
+        if t.type == "number" then
+            values[#values + 1] = t.value
+            self:advance()
+        elseif t.type == "string" then
+            values[#values + 1] = t.value
+            self:advance()
+        elseif t.type == "bool" then
+            values[#values + 1] = t.value
+            self:advance()
+        else
+            break
+        end
+    end
+
+    self:expect_type("close_bracket")
+    return values
+end
+
+--- Read PBRT parameter list: "type name" [values] pairs.
+--- Returns a table mapping param name -> { type = "float"|"integer"|"point3"|..., values = {...} }
+function Parser:read_params()
+    local params = {}
+    while true do
+        local t = self:peek()
+        if not t then break end
+        if t.type ~= "string" then break end
+
+        local param_spec = t.value
+        self:advance()
+
+        -- Parse "type name" format (supports multi-word types like "point3", "normal3", "rgb")
+        local ptype, pname = param_spec:match("^(%S+)%s+(%S+)$")
+        if not ptype then
+            -- Some PBRT files use just the name
+            pname = param_spec
+            ptype = "unknown"
+        end
+
+        -- Read the value: bracketed array, bare string, bare number, or bare bool
+        local next_tok = self:peek()
+        if next_tok and next_tok.type == "open_bracket" then
+            params[pname] = { type = ptype, values = self:read_bracket_array() }
+        elseif next_tok and next_tok.type == "string" then
+            -- Check this isn't the start of the next param spec (has "type name" format)
+            if next_tok.value:match("^%S+%s+%S+$") then
+                -- It's another param spec, not a value — store empty
+                params[pname] = { type = ptype, values = {} }
+            else
+                params[pname] = { type = ptype, values = { next_tok.value } }
+                self:advance()
+            end
+        elseif next_tok and next_tok.type == "number" then
+            params[pname] = { type = ptype, values = { next_tok.value } }
+            self:advance()
+        elseif next_tok and next_tok.type == "bool" then
+            params[pname] = { type = ptype, values = { next_tok.value } }
+            self:advance()
+        else
+            -- No value (flag-style param or missing value)
+            params[pname] = { type = ptype, values = {} }
+        end
+    end
+    return params
+end
+
+--- Get the current node list (top of stack or scene root).
+function Parser:current_nodes()
+    if self.current_object_name then
+        return self.objects[self.current_object_name]
+    end
+    if #self.node_stack > 0 then
+        return self.node_stack[#self.node_stack].children
+    end
+    return self.scene
+end
+
+--- Try to flatten a list of transform ops into a single {translate, rotate, scale}.
+--- Returns a flat table if possible, nil otherwise.
+--- Flattening works when we have at most one of each in T, R, S order.
+local function try_flatten_transforms(ops)
+    if #ops == 0 then return nil end
+
+    local translate, rotate, scale, matrix
+    local seen_types = {}
+
+    for _, op in ipairs(ops) do
+        if seen_types[op.type] then return nil end
+        seen_types[op.type] = true
+
+        if op.type == "translate" then
+            if seen_types["rotate"] or seen_types["scale"] or seen_types["matrix"] then return nil end
+            translate = op.value
+        elseif op.type == "rotate" then
+            if seen_types["scale"] or seen_types["matrix"] then return nil end
+            rotate = op.value
+        elseif op.type == "scale" then
+            if seen_types["matrix"] then return nil end
+            scale = op.value
+        elseif op.type == "matrix" then
+            matrix = op.value
+        else
+            return nil
+        end
+    end
+
+    local t = {}
+    local has_any = false
+    if translate then t.translate = translate; has_any = true end
+    if rotate then t.rotate = rotate; has_any = true end
+    if scale then t.scale = scale; has_any = true end
+    if matrix then t.matrix = matrix; has_any = true end
+    return has_any and t or nil
+end
+
+--- Convert a single transform op to a flat TRS table.
+local function op_to_transform(op)
+    if op.type == "translate" then
+        return { translate = op.value }
+    elseif op.type == "rotate" then
+        return { rotate = op.value }
+    elseif op.type == "scale" then
+        return { scale = op.value }
+    elseif op.type == "matrix" then
+        return { matrix = op.value }
+    end
+    return nil
+end
+
+--- Add a scene node to the current context.
+--- If the accumulated transforms can be flattened into a single TRS, attach directly.
+--- Otherwise, wrap in nested groups (one per transform op, outermost = first op).
+function Parser:add_node(node)
+    if #self.current_transforms == 0 then
+        local nodes = self:current_nodes()
+        nodes[#nodes + 1] = node
+        return
+    end
+
+    local flat = try_flatten_transforms(self.current_transforms)
+    if flat then
+        node.transform = flat
+        local nodes = self:current_nodes()
+        nodes[#nodes + 1] = node
+        return
+    end
+
+    -- Cannot flatten: wrap in nested groups.
+    -- PBRT applies transforms right-to-left (last specified = applied first).
+    -- Each group gets one transform, innermost = last op.
+    -- Build inside-out: start with the leaf node + last op, wrap outward.
+    local inner = node
+    for i = #self.current_transforms, 1, -1 do
+        local xf = op_to_transform(self.current_transforms[i])
+        if xf then
+            inner.transform = xf
+            if i > 1 then
+                inner = { type = "group", children = { inner } }
+            end
+        end
+    end
+
+    local nodes = self:current_nodes()
+    nodes[#nodes + 1] = inner
+end
+
+--- Record a TODO for an unsupported PBRT feature.
+function Parser:add_todo(msg)
+    self.todos[#self.todos + 1] = msg
+end
+
+-- ════════════════════════════════════════════════════════════════════
+-- Directive handlers
+-- ════════════════════════════════════════════════════════════════════
+
+function Parser:handle_LookAt()
+    local nums = self:read_numbers(9)
+    self.camera_eye = { nums[1], nums[2], nums[3] }
+    self.camera_target = { nums[4], nums[5], nums[6] }
+    self.camera_up = { nums[7], nums[8], nums[9] }
+end
+
+function Parser:handle_Camera()
+    local type_tok = self:expect_type("string")
+    local params = self:read_params()
+    if params.fov and params.fov.values[1] then
+        self.camera_fov = params.fov.values[1]
+    end
+    self.camera_type = type_tok and type_tok.value or "perspective"
+    if self.camera_type ~= "perspective" then
+        self:add_todo(string.format(
+            "Camera type '%s' not supported by ART (only 'perspective')", self.camera_type))
+    end
+    -- Collect unsupported camera params
+    for name, _ in pairs(params) do
+        if name ~= "fov" then
+            self:add_todo(string.format("Camera param '%s' not supported by ART", name))
+        end
+    end
+end
+
+function Parser:handle_Film()
+    local type_tok = self:expect_type("string")
+    local film_type = type_tok and type_tok.value or "image"
+    local params = self:read_params()
+    if params.xresolution and params.xresolution.values[1] then
+        self.film_width = math.floor(params.xresolution.values[1])
+    end
+    if params.yresolution and params.yresolution.values[1] then
+        self.film_height = math.floor(params.yresolution.values[1])
+    end
+    if params.filename and params.filename.values[1] then
+        -- Convert extension to .ppm since ART outputs PPM by default
+        local name = params.filename.values[1]
+        name = name:gsub("%.[^.]+$", ".ppm")
+        self.film_filename = name
+    end
+    -- Film type handling: "image" (v3), "rgb" (v4), "gbuffer", "spectral"
+    if film_type ~= "image" and film_type ~= "rgb" then
+        self:add_todo(string.format(
+            "Film type '%s' not supported by ART (using default output)", film_type))
+    end
+end
+
+function Parser:handle_WorldBegin()
+    -- Reset transform for world scope
+    self.current_transforms = {}
+end
+
+function Parser:handle_WorldEnd()
+    -- Nothing to do (v3 only; v4 doesn't have this)
+end
+
+function Parser:handle_AttributeBegin()
+    -- Push current transform state (deep copy)
+    self.transform_stack[#self.transform_stack + 1] = deep_copy(self.current_transforms)
+    -- Push a new group scope (children collected here)
+    self.node_stack[#self.node_stack + 1] = {
+        children = {},
+        transforms = deep_copy(self.current_transforms),
+    }
+    -- Reset transform for children (relative to this scope)
+    self.current_transforms = {}
+end
+
+function Parser:handle_AttributeEnd()
+    -- Pop the group scope
+    local scope = table.remove(self.node_stack)
+    if not scope then
+        io.stderr:write("warning: AttributeEnd without matching AttributeBegin\n")
+        return
+    end
+
+    -- Restore previous transform
+    self.current_transforms = table.remove(self.transform_stack) or {}
+
+    -- If the scope has children, emit them
+    if #scope.children == 1 then
+        -- Single child: emit directly
+        local child = scope.children[1]
+        local parent_nodes = self:current_nodes()
+        parent_nodes[#parent_nodes + 1] = child
+    elseif #scope.children > 1 then
+        -- Multiple children: wrap in a group
+        local group = { type = "group", children = scope.children }
+        local parent_nodes = self:current_nodes()
+        parent_nodes[#parent_nodes + 1] = group
+    end
+end
+
+function Parser:handle_TransformBegin()
+    self.transform_stack[#self.transform_stack + 1] = deep_copy(self.current_transforms)
+end
+
+function Parser:handle_TransformEnd()
+    self.current_transforms = table.remove(self.transform_stack) or {}
+end
+
+function Parser:handle_Translate()
+    local nums = self:read_numbers(3)
+    self.current_transforms[#self.current_transforms + 1] = {
+        type = "translate",
+        value = { nums[1], nums[2], nums[3] },
+    }
+end
+
+function Parser:handle_Rotate()
+    -- PBRT: Rotate angle x y z (angle in degrees)
+    local nums = self:read_numbers(4)
+    self.current_transforms[#self.current_transforms + 1] = {
+        type = "rotate",
+        value = {
+            angle = math.rad(nums[1]),
+            axis = { nums[2], nums[3], nums[4] },
+        },
+    }
+end
+
+function Parser:handle_Scale()
+    local nums = self:read_numbers(3)
+    local scale_val
+    if nums[1] == nums[2] and nums[2] == nums[3] then
+        scale_val = nums[1]
+    else
+        scale_val = { nums[1], nums[2], nums[3] }
+    end
+    self.current_transforms[#self.current_transforms + 1] = {
+        type = "scale",
+        value = scale_val,
+    }
+end
+
+function Parser:handle_Identity()
+    self.current_transforms = {}
+end
+
+function Parser:handle_ConcatTransform()
+    local vals = self:read_bracket_array()
+    if vals and #vals == 16 then
+        -- Store the raw 4x4 matrix (column-major, as PBRT specifies).
+        -- ART's parse_transform doesn't read 'matrix' yet, but we
+        -- preserve it for future use / round-trip fidelity.
+        self.current_transforms[#self.current_transforms + 1] = {
+            type = "matrix",
+            value = vals,
+        }
+    else
+        io.stderr:write("warning: ConcatTransform expected 16 values\n")
+        self:add_todo("ConcatTransform with unexpected element count")
+    end
+end
+
+function Parser:handle_Transform()
+    -- Transform replaces the CTM entirely (vs ConcatTransform which multiplies)
+    -- For our purposes we treat it the same way: store the matrix.
+    self.current_transforms = {} -- replace, not accumulate
+    local vals = self:read_bracket_array()
+    if vals and #vals == 16 then
+        self.current_transforms[#self.current_transforms + 1] = {
+            type = "matrix",
+            value = vals,
+        }
+    else
+        io.stderr:write("warning: Transform expected 16 values\n")
+        self:add_todo("Transform with unexpected element count")
+    end
+end
+
+function Parser:handle_Shape()
+    local type_tok = self:expect_type("string")
+    if not type_tok then return end
+    local shape_type = type_tok.value
+    local params = self:read_params()
+
+    if shape_type == "sphere" then
+        local node = { type = "sphere" }
+        -- PBRT sphere has a radius param; ART sphere is unit, so scale
+        if params.radius and params.radius.values[1] then
+            local r = params.radius.values[1]
+            if r ~= 1 then
+                self.current_transforms[#self.current_transforms + 1] = {
+                    type = "scale",
+                    value = r,
+                }
+            end
+        end
+        self:add_node(node)
+
+    elseif shape_type == "disk" then
+        -- PBRT disk can have height, radius, innerradius, phimax
+        local node = { type = "disk" }
+        if params.radius and params.radius.values[1] and params.radius.values[1] ~= 1 then
+            self.current_transforms[#self.current_transforms + 1] = {
+                type = "scale",
+                value = params.radius.values[1],
+            }
+        end
+        if params.height and params.height.values[1] and params.height.values[1] ~= 0 then
+            self.current_transforms[#self.current_transforms + 1] = {
+                type = "translate",
+                value = { 0, 0, params.height.values[1] },
+            }
+        end
+        self:add_node(node)
+
+    elseif shape_type == "cylinder" then
+        local node = { type = "cylinder" }
+        self:add_node(node)
+
+    elseif shape_type == "cone" then
+        -- PBRT cone: radius, height, phimax — no direct ART equivalent
+        local node = {
+            type = "sphere",
+            _comment = string.format(
+                "TODO: cone (radius=%s, height=%s) — no ART cone primitive",
+                params.radius and tostring(params.radius.values[1]) or "1",
+                params.height and tostring(params.height.values[1]) or "1"),
+        }
+        self:add_node(node)
+        self:add_todo("Shape 'cone' emitted as placeholder sphere (no ART cone primitive)")
+
+    elseif shape_type == "paraboloid" then
+        local node = {
+            type = "sphere",
+            _comment = string.format(
+                "TODO: paraboloid (radius=%s, zmin=%s, zmax=%s) — no ART paraboloid primitive",
+                params.radius and tostring(params.radius.values[1]) or "1",
+                params.zmin and tostring(params.zmin.values[1]) or "0",
+                params.zmax and tostring(params.zmax.values[1]) or "1"),
+        }
+        self:add_node(node)
+        self:add_todo("Shape 'paraboloid' emitted as placeholder sphere (no ART paraboloid primitive)")
+
+    elseif shape_type == "hyperboloid" then
+        local node = {
+            type = "sphere",
+            _comment = "TODO: hyperboloid — no ART hyperboloid primitive",
+        }
+        self:add_node(node)
+        self:add_todo("Shape 'hyperboloid' emitted as placeholder sphere (no ART hyperboloid primitive)")
+
+    elseif shape_type == "curve" then
+        -- PBRT curve: extremely common (5.9M instances in test corpus).
+        -- Parameters: type (flat/ribbon/cylinder), P (control points),
+        -- width/width0/width1, splitdepth, etc.
+        local curve_type = params.type and params.type.values[1] or "flat"
+        local npts = params.P and #params.P.values / 3 or 0
+        local node = {
+            type = "sphere",
+            _comment = string.format(
+                "TODO: curve (type='%s', %d control points) — no ART curve primitive",
+                curve_type, npts),
+        }
+        self:add_node(node)
+        self:add_todo("Shape 'curve' emitted as placeholder sphere (no ART curve primitive)")
+
+    elseif shape_type == "trianglemesh" then
+        local indices = params.indices or params.index
+        local points = params.P or params.point
+
+        if indices and points then
+            -- Convert flat arrays to structured data
+            local verts = {}
+            for i = 1, #points.values, 3 do
+                verts[#verts + 1] = {
+                    points.values[i],
+                    points.values[i + 1],
+                    points.values[i + 2],
+                }
+            end
+
+            local tris = {}
+            for i = 1, #indices.values, 3 do
+                tris[#tris + 1] = {
+                    indices.values[i],
+                    indices.values[i + 1],
+                    indices.values[i + 2],
+                }
+            end
+
+            local node = {
+                type = "mesh",
+                vertices = verts,
+                triangles = tris,
+            }
+
+            -- Extract normals if present
+            local normals = params.N or params.normal
+            if normals and #normals.values >= 3 then
+                node._comment = "TODO: normals present but not emitted"
+                self:add_todo("trianglemesh normals (N) not yet mapped to ART mesh")
+            end
+
+            -- Extract UVs if present
+            local uvs = params.uv or params.st
+            if uvs and #uvs.values >= 2 then
+                if not node._comment then
+                    node._comment = "TODO: UVs present but not emitted"
+                end
+                self:add_todo("trianglemesh UVs (uv/st) not yet mapped to ART mesh")
+            end
+
+            self:add_node(node)
+        else
+            -- Emit as comment
+            self:add_node({
+                type = "sphere", -- placeholder
+                _comment = "TODO: trianglemesh missing indices or P data",
+            })
+        end
+
+    elseif shape_type == "bilinearmesh" then
+        -- v4: quad mesh — each quad has 4 vertex indices, tessellate into 2 triangles
+        local indices = params.indices or params.index
+        local points = params.P or params.point
+
+        if indices and points then
+            local verts = {}
+            for i = 1, #points.values, 3 do
+                verts[#verts + 1] = {
+                    points.values[i],
+                    points.values[i + 1],
+                    points.values[i + 2],
+                }
+            end
+
+            -- Quad indices -> triangle pairs
+            local tris = {}
+            for i = 1, #indices.values, 4 do
+                local v0 = indices.values[i]
+                local v1 = indices.values[i + 1]
+                local v2 = indices.values[i + 2]
+                local v3 = indices.values[i + 3]
+                tris[#tris + 1] = { v0, v1, v2 }
+                tris[#tris + 1] = { v0, v2, v3 }
+            end
+
+            local node = {
+                type = "mesh",
+                vertices = verts,
+                triangles = tris,
+                _comment = "bilinearmesh tessellated to triangles",
+            }
+            self:add_node(node)
+        else
+            self:add_node({
+                type = "sphere",
+                _comment = "TODO: bilinearmesh missing indices or P data",
+            })
+        end
+
+    elseif shape_type == "loopsubdiv" then
+        -- Loop subdivision surface — emit with mesh data if available
+        local indices = params.indices or params.index
+        local points = params.P or params.point
+
+        if indices and points then
+            local verts = {}
+            for i = 1, #points.values, 3 do
+                verts[#verts + 1] = {
+                    points.values[i],
+                    points.values[i + 1],
+                    points.values[i + 2],
+                }
+            end
+
+            local tris = {}
+            for i = 1, #indices.values, 3 do
+                tris[#tris + 1] = {
+                    indices.values[i],
+                    indices.values[i + 1],
+                    indices.values[i + 2],
+                }
+            end
+
+            self:add_node({
+                type = "mesh",
+                vertices = verts,
+                triangles = tris,
+                _comment = "TODO: loopsubdiv (control mesh only, no subdivision applied)",
+            })
+        else
+            self:add_node({
+                type = "sphere",
+                _comment = "TODO: loopsubdiv without inline mesh data",
+            })
+        end
+        self:add_todo("Loop subdivision surface emitted as control mesh (no subdivision applied)")
+
+    elseif shape_type == "plymesh" then
+        -- PLY mesh: emit as TODO comment with path
+        -- TODO: add PLY reading to quiver (quiver::utils::io::PlyReader)
+        local filename = params.filename and params.filename.values[1]
+        self:add_node({
+            type = "sphere", -- placeholder
+            _comment = string.format("TODO: plymesh '%s' — load via quiver I/O (quiver PLY reader needed)",
+                filename or "unknown"),
+        })
+        self:add_todo(string.format("PLY mesh '%s' requires quiver PLY reader (placeholder sphere emitted)",
+            filename or "unknown"))
+
+    else
+        -- Unknown shape: emit placeholder
+        self:add_node({
+            type = "sphere",
+            _comment = string.format("TODO: unsupported shape '%s'", shape_type),
+        })
+        self:add_todo(string.format("Unsupported shape type '%s'", shape_type))
+    end
+end
+
+function Parser:handle_ObjectBegin()
+    local name_tok = self:expect_type("string")
+    if not name_tok then return end
+    self.current_object_name = name_tok.value
+    self.objects[name_tok.value] = {}
+    self.transform_stack[#self.transform_stack + 1] = deep_copy(self.current_transforms)
+    self.current_transforms = {}
+end
+
+function Parser:handle_ObjectEnd()
+    self.current_object_name = nil
+    self.current_transforms = table.remove(self.transform_stack) or {}
+end
+
+function Parser:handle_ObjectInstance()
+    local name_tok = self:expect_type("string")
+    if not name_tok then return end
+    local name = name_tok.value
+
+    local obj_nodes = self.objects[name]
+    if not obj_nodes or #obj_nodes == 0 then
+        io.stderr:write(string.format("warning: ObjectInstance '%s' not found\n", name))
+        return
+    end
+
+    -- Deep copy the nodes and add them
+    for _, node in ipairs(obj_nodes) do
+        self:add_node(deep_copy(node))
+    end
+end
+
+function Parser:handle_Include()
+    local path_tok = self:expect_type("string")
+    if not path_tok then return end
+
+    local filepath = self.base_dir .. "/" .. path_tok.value
+    local f = io.open(filepath, "r")
+    if not f then
+        io.stderr:write(string.format("warning: cannot open Include file: %s\n", filepath))
+        return
+    end
+    local content = f:read("*a")
+    f:close()
+
+    -- Tokenize and parse the included file
+    local inc_tokens = tokenize(content)
+    local saved_tokens = self.tokens
+    local saved_pos = self.pos
+
+    -- Set base_dir for nested includes relative to the included file
+    local inc_dir = filepath:match("(.+)/[^/]+$") or self.base_dir
+    local saved_base = self.base_dir
+    self.base_dir = inc_dir
+
+    self.tokens = inc_tokens
+    self.pos = 1
+    self:parse_directives()
+
+    self.tokens = saved_tokens
+    self.pos = saved_pos
+    self.base_dir = saved_base
+end
+
+-- Import is the v4 equivalent of Include (same behavior for our purposes)
+Parser.handle_Import = Parser.handle_Include
+
+-- ─────────────────────────────────────────────────────────────────
+-- Unsupported directive handlers
+-- ─────────────────────────────────────────────────────────────────
+
+--- Directives that take: "type-string" + param list
+local directives_string_params = {
+    Material = true, MakeNamedMaterial = true,
+    LightSource = true, AreaLightSource = true,
+    Integrator = true, Sampler = true,
+    PixelFilter = true, Accelerator = true,
+    CoordSysTransform = true,
+}
+
+--- Directives that take: "name-string" only (no params)
+local directives_string_only = {
+    NamedMaterial = true,
+    CoordinateSystem = true,
+}
+
+--- Texture: "name" "type" "class" + params (3 strings)
+function Parser:handle_Texture()
+    local name = self:expect_type("string")
+    local ttype = self:expect_type("string")
+    local tclass = self:expect_type("string")
+    local params = self:read_params()
+    local desc = string.format("Texture '%s' (type='%s', class='%s')",
+        name and name.value or "?",
+        ttype and ttype.value or "?",
+        tclass and tclass.value or "?")
+    self:add_todo(desc .. " — textures not supported by ART")
+end
+
+--- MediumInterface: "interior" "exterior" (2 bare strings, no params)
+function Parser:handle_MediumInterface()
+    local interior = self:peek()
+    if interior and interior.type == "string" then
+        self:advance()
+    end
+    local exterior = self:peek()
+    if exterior and exterior.type == "string" then
+        self:advance()
+    end
+    self:add_todo("MediumInterface not supported by ART")
+end
+
+--- MakeNamedMedium: "name" + params
+function Parser:handle_MakeNamedMedium()
+    local name = self:expect_type("string")
+    local params = self:read_params()
+    self:add_todo(string.format("MakeNamedMedium '%s' not supported by ART",
+        name and name.value or "?"))
+end
+
+function Parser:handle_ReverseOrientation()
+    -- Ignored
+end
+
+--- ActiveTransform (v4): consumes identifier (All/StartTime/EndTime)
+function Parser:handle_ActiveTransform()
+    local t = self:peek()
+    if t and t.type == "identifier" then
+        self:advance()
+    end
+end
+
+--- Generic unsupported directive: try to consume "string" + params
+function Parser:handle_unsupported_directive(name)
+    local t = self:peek()
+    if t and t.type == "string" then
+        self:advance()
+        self:read_params()
+    end
+    self:add_todo(string.format("Directive '%s' not supported by ART", name))
+end
+
+-- ════════════════════════════════════════════════════════════════════
+-- Main parse loop
+-- ════════════════════════════════════════════════════════════════════
+
+function Parser:parse_directives()
+    while self.pos <= #self.tokens do
+        local t = self:peek()
+        if not t then break end
+
+        if t.type ~= "identifier" then
+            self:advance()
+        else
+            local name = t.value
+            self:advance()
+
+            if name == "LookAt" then self:handle_LookAt()
+            elseif name == "Camera" then self:handle_Camera()
+            elseif name == "Film" then self:handle_Film()
+            elseif name == "WorldBegin" then self:handle_WorldBegin()
+            elseif name == "WorldEnd" then self:handle_WorldEnd()
+            elseif name == "AttributeBegin" then self:handle_AttributeBegin()
+            elseif name == "AttributeEnd" then self:handle_AttributeEnd()
+            elseif name == "TransformBegin" then self:handle_TransformBegin()
+            elseif name == "TransformEnd" then self:handle_TransformEnd()
+            elseif name == "Translate" then self:handle_Translate()
+            elseif name == "Rotate" then self:handle_Rotate()
+            elseif name == "Scale" then self:handle_Scale()
+            elseif name == "Identity" then self:handle_Identity()
+            elseif name == "ConcatTransform" then self:handle_ConcatTransform()
+            elseif name == "Transform" then self:handle_Transform()
+            elseif name == "Shape" then self:handle_Shape()
+            elseif name == "ObjectBegin" then self:handle_ObjectBegin()
+            elseif name == "ObjectEnd" then self:handle_ObjectEnd()
+            elseif name == "ObjectInstance" then self:handle_ObjectInstance()
+            elseif name == "Include" then self:handle_Include()
+            elseif name == "Import" then self:handle_Import()
+            elseif name == "Texture" then self:handle_Texture()
+            elseif name == "MediumInterface" then self:handle_MediumInterface()
+            elseif name == "MakeNamedMedium" then self:handle_MakeNamedMedium()
+            elseif name == "ReverseOrientation" then self:handle_ReverseOrientation()
+            elseif name == "ActiveTransform" then self:handle_ActiveTransform()
+            elseif directives_string_params[name] then
+                -- Consume "type" string + params, record TODO
+                local type_str = self:peek()
+                local type_name = ""
+                if type_str and type_str.type == "string" then
+                    type_name = type_str.value
+                    self:advance()
+                end
+                self:read_params()
+                self:add_todo(string.format("%s '%s' not supported by ART", name, type_name))
+            elseif directives_string_only[name] then
+                local str_tok = self:peek()
+                if str_tok and str_tok.type == "string" then
+                    self:advance()
+                end
+                self:add_todo(string.format("%s not supported by ART", name))
+            else
+                -- Unknown directive — try generic consumption
+                self:handle_unsupported_directive(name)
+            end
+        end
+    end
+end
+
+function Parser:parse(source)
+    self.tokens = tokenize(source)
+    self.pos = 1
+    self:parse_directives()
+end
+
+-- ════════════════════════════════════════════════════════════════════
+-- Lua output generation
+-- ════════════════════════════════════════════════════════════════════
+
+local function indent(depth)
+    return string.rep("    ", depth)
+end
+
+local function fmt_num(v)
+    if v == math.floor(v) and math.abs(v) < 1e15 then
+        return string.format("%g", v)
+    end
+    return string.format("%.10g", v)
+end
+
+local function fmt_vec(v)
+    local parts = {}
+    for _, x in ipairs(v) do
+        parts[#parts + 1] = fmt_num(x)
+    end
+    return "{" .. table.concat(parts, ", ") .. "}"
+end
+
+--- Emit a transform table at the given indent depth.
+local function emit_transform(xf, depth)
+    if not xf then return "" end
+
+    local lines = {}
+    lines[#lines + 1] = indent(depth) .. "transform = {"
+
+    if xf.translate then
+        lines[#lines + 1] = indent(depth + 1) .. "translate = " .. fmt_vec(xf.translate) .. ","
+    end
+    if xf.rotate then
+        lines[#lines + 1] = indent(depth + 1) .. string.format(
+            "rotate = {angle = %s, axis = %s},",
+            fmt_num(xf.rotate.angle),
+            fmt_vec(xf.rotate.axis))
+    end
+    if xf.scale then
+        if type(xf.scale) == "number" then
+            lines[#lines + 1] = indent(depth + 1) .. "scale = " .. fmt_num(xf.scale) .. ","
+        else
+            lines[#lines + 1] = indent(depth + 1) .. "scale = " .. fmt_vec(xf.scale) .. ","
+        end
+    end
+    if xf.matrix then
+        lines[#lines + 1] = indent(depth + 1) .. "-- TODO: matrix transform (ART parse_transform does not read 'matrix' yet)"
+        lines[#lines + 1] = indent(depth + 1) .. "matrix = " .. fmt_vec(xf.matrix) .. ","
+    end
+
+    lines[#lines + 1] = indent(depth) .. "},"
+    return table.concat(lines, "\n")
+end
+
+local function emit_node(node, depth)
+    local lines = {}
+
+    if node._comment then
+        lines[#lines + 1] = indent(depth) .. "-- " .. node._comment
+    end
+
+    lines[#lines + 1] = indent(depth) .. "{"
+
+    if node.type == "group" then
+        lines[#lines + 1] = indent(depth + 1) .. 'type = "group",'
+        if node.transform then
+            lines[#lines + 1] = emit_transform(node.transform, depth + 1)
+        end
+        if node.children and #node.children > 0 then
+            lines[#lines + 1] = indent(depth + 1) .. "children = {"
+            for _, child in ipairs(node.children) do
+                lines[#lines + 1] = emit_node(child, depth + 2)
+            end
+            lines[#lines + 1] = indent(depth + 1) .. "},"
+        end
+
+    elseif node.type == "mesh" then
+        lines[#lines + 1] = indent(depth + 1) .. 'type = "mesh",'
+        if node.transform then
+            lines[#lines + 1] = emit_transform(node.transform, depth + 1)
+        end
+
+        -- Vertices
+        if node.vertices then
+            lines[#lines + 1] = indent(depth + 1) .. "vertices = {"
+            for _, v in ipairs(node.vertices) do
+                lines[#lines + 1] = indent(depth + 2) .. fmt_vec(v) .. ","
+            end
+            lines[#lines + 1] = indent(depth + 1) .. "},"
+        end
+
+        -- Triangles
+        if node.triangles then
+            lines[#lines + 1] = indent(depth + 1) .. "triangles = {"
+            for _, tri in ipairs(node.triangles) do
+                lines[#lines + 1] = indent(depth + 2) .. fmt_vec(tri) .. ","
+            end
+            lines[#lines + 1] = indent(depth + 1) .. "},"
+        end
+
+    else
+        -- Simple geometry types (sphere, box, plane, disk, cylinder, triangle)
+        lines[#lines + 1] = indent(depth + 1) .. string.format('type = "%s",', node.type)
+        if node.transform then
+            lines[#lines + 1] = emit_transform(node.transform, depth + 1)
+        end
+    end
+
+    lines[#lines + 1] = indent(depth) .. "},"
+    return table.concat(lines, "\n")
+end
+
+--- Generate Lua source from a parsed result.
+--- @param result table  A table with .scene, .camera_*, .film_*, .todos fields
+---                      (as returned by parse_file or parse_source).
+--- @return string       Lua source code
+local function to_lua(result)
+    local lines = {}
+    lines[#lines + 1] = "-- Converted from PBRT by pbrt_to_lua.lua"
+
+    -- Emit TODO summary at top if there are unsupported features
+    if result.todos and #result.todos > 0 then
+        -- Deduplicate
+        local seen = {}
+        local unique = {}
+        for _, msg in ipairs(result.todos) do
+            if not seen[msg] then
+                seen[msg] = true
+                unique[#unique + 1] = msg
+            end
+        end
+        lines[#lines + 1] = "--"
+        lines[#lines + 1] = "-- Unsupported PBRT features (require ART implementation):"
+        for _, msg in ipairs(unique) do
+            lines[#lines + 1] = "--   TODO: " .. msg
+        end
+    end
+
+    lines[#lines + 1] = ""
+    lines[#lines + 1] = "return {"
+
+    -- Render settings
+    lines[#lines + 1] = indent(1) .. "render = {"
+    lines[#lines + 1] = indent(2) .. "width = " .. result.film_width .. ","
+    lines[#lines + 1] = indent(2) .. "height = " .. result.film_height .. ","
+    lines[#lines + 1] = indent(2) .. 'output = "' .. result.film_filename .. '",'
+    lines[#lines + 1] = indent(2) .. 'accelerator = "bvh",'
+    lines[#lines + 1] = indent(1) .. "},"
+
+    -- Camera
+    lines[#lines + 1] = ""
+    local eye = result.camera_eye or {0, 0, 5}
+    local target = result.camera_target or {0, 0, 0}
+    local up = result.camera_up or {0, 1, 0}
+    lines[#lines + 1] = indent(1) .. "camera = {"
+    lines[#lines + 1] = indent(2) .. "position = " .. fmt_vec(eye) .. ","
+    lines[#lines + 1] = indent(2) .. "target = " .. fmt_vec(target) .. ","
+    lines[#lines + 1] = indent(2) .. "up = " .. fmt_vec(up) .. ","
+    if result.camera_fov and result.camera_fov ~= 45 then
+        lines[#lines + 1] = indent(2) .. "-- TODO: fov = " .. fmt_num(result.camera_fov)
+            .. " (not yet supported by ART Camera)"
+    end
+    lines[#lines + 1] = indent(1) .. "},"
+
+    -- Scene
+    lines[#lines + 1] = ""
+    lines[#lines + 1] = indent(1) .. "scene = {"
+    for _, node in ipairs(result.scene) do
+        lines[#lines + 1] = emit_node(node, 2)
+    end
+    lines[#lines + 1] = indent(1) .. "},"
+
+    lines[#lines + 1] = "}"
+    return table.concat(lines, "\n") .. "\n"
+end
+
+-- ════════════════════════════════════════════════════════════════════
+-- Module API
+-- ════════════════════════════════════════════════════════════════════
+
+--- Parse a PBRT source string.
+--- @param source string   PBRT file contents
+--- @param opts   table?   Optional: { base_dir = "." }
+--- @return table result   Table with .scene, .todos, .camera_*, .film_* fields
+function M.parse_source(source, opts)
+    opts = opts or {}
+    local parser = Parser.new({})
+    parser.base_dir = opts.base_dir or "."
+    parser:parse(source)
+    -- Return a plain result table (not the Parser metatable)
+    return {
+        scene = parser.scene,
+        todos = parser.todos,
+        camera_eye = parser.camera_eye,
+        camera_target = parser.camera_target,
+        camera_up = parser.camera_up,
+        camera_fov = parser.camera_fov,
+        camera_type = parser.camera_type,
+        film_width = parser.film_width,
+        film_height = parser.film_height,
+        film_filename = parser.film_filename,
+        objects = parser.objects,
+    }
+end
+
+--- Parse a PBRT file from disk.
+--- @param path string   Path to a .pbrt file
+--- @return table result   (same as parse_source)
+--- @return nil           on error: returns nil, error_message
+function M.parse_file(path)
+    local f, err = io.open(path, "r")
+    if not f then return nil, err end
+    local source = f:read("*a")
+    f:close()
+    local base_dir = path:match("(.+)/[^/]+$") or "."
+    return M.parse_source(source, { base_dir = base_dir })
+end
+
+--- Generate Lua source code from a parsed result.
+--- @param result table   As returned by parse_file / parse_source
+--- @return string        Lua source code
+M.to_lua = to_lua
+
+--- Convenience: parse a PBRT file and write the Lua output.
+--- @param input_path  string   Path to input .pbrt file
+--- @param output_path string?  Path to output .lua file (nil = return string)
+--- @return string|nil          Lua source if output_path is nil
+function M.convert_file(input_path, output_path)
+    local result, err = M.parse_file(input_path)
+    if not result then
+        error(string.format("cannot open '%s': %s", input_path, err or "unknown error"))
+    end
+
+    local lua_output = M.to_lua(result)
+
+    if output_path then
+        local out, werr = io.open(output_path, "w")
+        if not out then
+            error(string.format("cannot open '%s' for writing: %s", output_path, werr or "unknown"))
+        end
+        out:write(lua_output)
+        out:close()
+        io.stderr:write(string.format("Converted %s -> %s\n", input_path, output_path))
+        return nil
+    end
+
+    return lua_output
+end
+
+-- ════════════════════════════════════════════════════════════════════
+-- CLI entry point (only when run directly, not when require()'d)
+-- ════════════════════════════════════════════════════════════════════
+
+local function main()
+    if #arg < 1 then
+        io.stderr:write("Usage: lua pbrt_to_lua.lua <input.pbrt> [output.lua]\n")
+        os.exit(1)
+    end
+
+    local input_path = arg[1]
+    local output_path = arg[2] -- optional, defaults to stdout
+
+    if output_path then
+        M.convert_file(input_path, output_path)
+    else
+        local lua_output = M.convert_file(input_path)
+        io.write(lua_output)
+    end
+end
+
+-- Run main() only when executed directly (not when loaded via require())
+if arg and arg[0] and arg[0]:match("pbrt_to_lua%.lua$") then
+    main()
+end
+
+return M

--- a/tools/validate_roundtrip.lua
+++ b/tools/validate_roundtrip.lua
@@ -78,9 +78,18 @@ local function validate_lua_syntax(lua_source, source_name)
     return true, result
 end
 
+--- Maximum PBRT output size (bytes) to validate with `pbrt --format`.
+--- Larger files (e.g. 3M placeholder spheres for curve-heavy scenes) are skipped.
+local MAX_PBRT_VALIDATE_SIZE = 50 * 1024 * 1024  -- 50 MB
+
 --- Validate PBRT source by running `pbrt --format` on it.
---- Returns true on success, false + error message on failure.
+--- Returns true on success, false + error message on failure,
+--- or true + "skipped" if the output exceeds the size limit.
 local function validate_with_pbrt(pbrt_source, pbrt_bin)
+    if #pbrt_source > MAX_PBRT_VALIDATE_SIZE then
+        return true, "skipped (output too large: " .. math.floor(#pbrt_source / 1024 / 1024) .. " MB)"
+    end
+
     local tmpf = os.tmpname()
     local f = io.open(tmpf, "w")
     if not f then return false, "cannot create temp file" end
@@ -94,13 +103,20 @@ local function validate_with_pbrt(pbrt_source, pbrt_bin)
     local exit_code = tonumber(exit_str) or 1
 
     if exit_code ~= 0 then
+        os.remove(tmpf)
+        -- Decode signal-based exits
+        if exit_code >= 128 then
+            local sig = exit_code - 128
+            local signames = {[11] = "SIGSEGV", [9] = "SIGKILL", [6] = "SIGABRT"}
+            local signame = signames[sig] or ("signal " .. sig)
+            return false, string.format("pbrt crashed (%s, exit %d)", signame, exit_code)
+        end
         -- Re-run to capture error message
         handle = io.popen(string.format('%s --format "%s" 2>&1', pbrt_bin, tmpf))
         local output = handle:read("*a")
         handle:close()
-        os.remove(tmpf)
         -- Extract first error line
-        local errmsg = "unknown error"
+        local errmsg = "unknown error (exit " .. exit_code .. ")"
         for line in output:gmatch("[^\n]+") do
             if line:lower():match("error") then
                 errmsg = line
@@ -168,6 +184,7 @@ local function main()
     local roundtrip_fail = 0
     local pbrt_pass = 0
     local pbrt_fail = 0
+    local pbrt_skip = 0
     local failures = {}
 
     for i, filepath in ipairs(files) do
@@ -194,15 +211,22 @@ local function main()
                 -- Step 2: optional pbrt binary validation (PBRT -> Lua -> PBRT -> pbrt --format)
                 if pbrt_bin then
                     local pbrt_source = l2p.to_pbrt(result)
-                    local pbrt_ok, pbrt_err = validate_with_pbrt(pbrt_source, pbrt_bin)
+                    local pbrt_ok, pbrt_info = validate_with_pbrt(pbrt_source, pbrt_bin)
                     if pbrt_ok then
-                        pbrt_pass = pbrt_pass + 1
-                        if verbose then
-                            io.stderr:write(string.format("  [PBRT-PASS] %s\n", short))
+                        if pbrt_info and pbrt_info:match("^skipped") then
+                            pbrt_skip = pbrt_skip + 1
+                            if verbose then
+                                io.stderr:write(string.format("  [PBRT-SKIP] %s: %s\n", short, pbrt_info))
+                            end
+                        else
+                            pbrt_pass = pbrt_pass + 1
+                            if verbose then
+                                io.stderr:write(string.format("  [PBRT-PASS] %s\n", short))
+                            end
                         end
                     else
                         pbrt_fail = pbrt_fail + 1
-                        local msg = string.format("  [PBRT-FAIL] %s: %s", short, pbrt_err)
+                        local msg = string.format("  [PBRT-FAIL] %s: %s", short, pbrt_info)
                         failures[#failures + 1] = msg
                         if verbose then io.stderr:write(msg .. "\n") end
                         if stop_on_error then break end
@@ -249,8 +273,8 @@ local function main()
     io.stderr:write(string.format("  PBRT -> Lua:  %d pass, %d fail (of %d files)\n",
         pass, fail, #files))
     if pbrt_bin then
-        io.stderr:write(string.format("  pbrt verify:  %d pass, %d fail\n",
-            pbrt_pass, pbrt_fail))
+        io.stderr:write(string.format("  pbrt verify:  %d pass, %d fail, %d skipped\n",
+            pbrt_pass, pbrt_fail, pbrt_skip))
     end
     if do_roundtrip then
         io.stderr:write(string.format("  Round-trip:   %d pass, %d fail\n",

--- a/tools/validate_roundtrip.lua
+++ b/tools/validate_roundtrip.lua
@@ -3,15 +3,24 @@
 ---
 --- For each .pbrt file found, converts to Lua and checks that the output
 --- is valid Lua syntax (loads without errors). Optionally tests round-trip
---- by converting Lua -> PBRT -> Lua and comparing.
+--- by converting Lua -> PBRT -> Lua and comparing. With --pbrt, also
+--- validates the generated PBRT output using the actual pbrt binary.
 ---
 --- Usage:
----   lua validate_roundtrip.lua <scenes_dir> [--roundtrip] [--verbose] [--stop-on-error] [--max-size=N]
+---   lua validate_roundtrip.lua <scenes_dir> [options]
+---
+--- Options:
+---   --roundtrip          Also test Lua -> PBRT -> Lua round-trip
+---   --pbrt=<path>        Validate generated PBRT with `pbrt --format`
+---   --verbose            Print per-file results
+---   --stop-on-error      Stop at first failure
+---   --max-size=N         Skip .pbrt files larger than N bytes
 ---
 --- Examples:
 ---   lua validate_roundtrip.lua ../pbrt-scenes/pbrt-v4-scenes/
 ---   lua validate_roundtrip.lua ../pbrt-scenes/ --roundtrip --verbose
----   lua validate_roundtrip.lua ../pbrt-scenes/ --max-size=5000000  (skip files > 5MB)
+---   lua validate_roundtrip.lua ../pbrt-scenes/ --max-size=5000000
+---   lua validate_roundtrip.lua ../pbrt-scenes/ --pbrt=$HOME/git/pbrt-v4/build/pbrt
 
 -- Add tools/ to package.path so we can require the converters
 local script_dir = arg[0]:match("(.+)/[^/]+$") or "."
@@ -66,6 +75,42 @@ local function validate_lua_syntax(lua_source, source_name)
     if not result.scene then
         return false, "missing 'scene' key in returned table"
     end
+    return true, result
+end
+
+--- Validate PBRT source by running `pbrt --format` on it.
+--- Returns true on success, false + error message on failure.
+local function validate_with_pbrt(pbrt_source, pbrt_bin)
+    local tmpf = os.tmpname()
+    local f = io.open(tmpf, "w")
+    if not f then return false, "cannot create temp file" end
+    f:write(pbrt_source)
+    f:close()
+
+    local handle = io.popen(string.format(
+        '%s --format "%s" >/dev/null 2>&1; echo $?', pbrt_bin, tmpf))
+    local exit_str = handle:read("*a"):match("%d+")
+    handle:close()
+    local exit_code = tonumber(exit_str) or 1
+
+    if exit_code ~= 0 then
+        -- Re-run to capture error message
+        handle = io.popen(string.format('%s --format "%s" 2>&1', pbrt_bin, tmpf))
+        local output = handle:read("*a")
+        handle:close()
+        os.remove(tmpf)
+        -- Extract first error line
+        local errmsg = "unknown error"
+        for line in output:gmatch("[^\n]+") do
+            if line:lower():match("error") then
+                errmsg = line
+                break
+            end
+        end
+        return false, errmsg
+    end
+
+    os.remove(tmpf)
     return true, nil
 end
 
@@ -75,7 +120,7 @@ end
 
 local function main()
     if #arg < 1 then
-        io.stderr:write("Usage: lua validate_roundtrip.lua <scenes_dir> [--roundtrip] [--verbose] [--stop-on-error] [--max-size=N]\n")
+        io.stderr:write("Usage: lua validate_roundtrip.lua <scenes_dir> [--roundtrip] [--pbrt=<path>] [--verbose] [--stop-on-error] [--max-size=N]\n")
         os.exit(1)
     end
 
@@ -84,6 +129,7 @@ local function main()
     local verbose = false
     local stop_on_error = false
     local max_size = nil
+    local pbrt_bin = nil
 
     for i = 2, #arg do
         if arg[i] == "--roundtrip" then do_roundtrip = true end
@@ -91,6 +137,20 @@ local function main()
         if arg[i] == "--stop-on-error" then stop_on_error = true end
         local sz = arg[i]:match("^%-%-max%-size=(%d+)$")
         if sz then max_size = tonumber(sz) end
+        local pb = arg[i]:match("^%-%-pbrt=(.+)$")
+        if pb then pbrt_bin = pb end
+    end
+
+    -- Verify pbrt binary exists if specified
+    if pbrt_bin then
+        local test = io.popen(string.format('"%s" --help >/dev/null 2>&1; echo $?', pbrt_bin))
+        local rc = tonumber(test:read("*a"):match("%d+")) or 1
+        test:close()
+        if rc ~= 0 then
+            io.stderr:write(string.format("Error: pbrt binary not found or not executable: %s\n", pbrt_bin))
+            os.exit(1)
+        end
+        io.stderr:write(string.format("Using pbrt binary: %s\n", pbrt_bin))
     end
 
     local files = find_pbrt_files(scenes_dir, max_size)
@@ -106,6 +166,8 @@ local function main()
     local skip = 0
     local roundtrip_pass = 0
     local roundtrip_fail = 0
+    local pbrt_pass = 0
+    local pbrt_fail = 0
     local failures = {}
 
     for i, filepath in ipairs(files) do
@@ -129,7 +191,25 @@ local function main()
                         short, #result.scene, #result.todos))
                 end
 
-                -- Step 2: optional round-trip (Lua -> PBRT -> Lua)
+                -- Step 2: optional pbrt binary validation (PBRT -> Lua -> PBRT -> pbrt --format)
+                if pbrt_bin then
+                    local pbrt_source = l2p.to_pbrt(result)
+                    local pbrt_ok, pbrt_err = validate_with_pbrt(pbrt_source, pbrt_bin)
+                    if pbrt_ok then
+                        pbrt_pass = pbrt_pass + 1
+                        if verbose then
+                            io.stderr:write(string.format("  [PBRT-PASS] %s\n", short))
+                        end
+                    else
+                        pbrt_fail = pbrt_fail + 1
+                        local msg = string.format("  [PBRT-FAIL] %s: %s", short, pbrt_err)
+                        failures[#failures + 1] = msg
+                        if verbose then io.stderr:write(msg .. "\n") end
+                        if stop_on_error then break end
+                    end
+                end
+
+                -- Step 3: optional round-trip (Lua -> PBRT -> Lua)
                 if do_roundtrip then
                     local pbrt_source = l2p.to_pbrt(result)
                     local rt_result = pbrt.parse_source(pbrt_source)
@@ -168,6 +248,10 @@ local function main()
     io.stderr:write(string.format("═══ Results ═══\n"))
     io.stderr:write(string.format("  PBRT -> Lua:  %d pass, %d fail (of %d files)\n",
         pass, fail, #files))
+    if pbrt_bin then
+        io.stderr:write(string.format("  pbrt verify:  %d pass, %d fail\n",
+            pbrt_pass, pbrt_fail))
+    end
     if do_roundtrip then
         io.stderr:write(string.format("  Round-trip:   %d pass, %d fail\n",
             roundtrip_pass, roundtrip_fail))
@@ -180,7 +264,7 @@ local function main()
         end
     end
 
-    os.exit(fail > 0 and 1 or 0)
+    os.exit((fail + pbrt_fail) > 0 and 1 or 0)
 end
 
 if arg and arg[0] and arg[0]:match("validate_roundtrip%.lua$") then

--- a/tools/validate_roundtrip.lua
+++ b/tools/validate_roundtrip.lua
@@ -1,0 +1,188 @@
+#!/usr/bin/env lua
+--- validate_roundtrip — Batch-validate PBRT -> Lua conversion across scene repos.
+---
+--- For each .pbrt file found, converts to Lua and checks that the output
+--- is valid Lua syntax (loads without errors). Optionally tests round-trip
+--- by converting Lua -> PBRT -> Lua and comparing.
+---
+--- Usage:
+---   lua validate_roundtrip.lua <scenes_dir> [--roundtrip] [--verbose] [--stop-on-error] [--max-size=N]
+---
+--- Examples:
+---   lua validate_roundtrip.lua ../pbrt-scenes/pbrt-v4-scenes/
+---   lua validate_roundtrip.lua ../pbrt-scenes/ --roundtrip --verbose
+---   lua validate_roundtrip.lua ../pbrt-scenes/ --max-size=5000000  (skip files > 5MB)
+
+-- Add tools/ to package.path so we can require the converters
+local script_dir = arg[0]:match("(.+)/[^/]+$") or "."
+package.path = script_dir .. "/?.lua;" .. package.path
+
+local pbrt = require("pbrt_to_lua")
+local l2p = require("lua_to_pbrt")
+
+-- ════════════════════════════════════════════════════════════════════
+-- File discovery
+-- ════════════════════════════════════════════════════════════════════
+
+--- Recursively find all .pbrt files under a directory.
+--- Uses `find` since Lua has no built-in directory traversal.
+--- @param dir string       Directory to search
+--- @param max_size number? Optional max file size in bytes (nil = no limit)
+local function find_pbrt_files(dir, max_size)
+    local size_filter = ""
+    if max_size then
+        size_filter = string.format(" -size -%dc", max_size)
+    end
+    local files = {}
+    local handle = io.popen(string.format(
+        'find "%s" -name "*.pbrt" -type f%s 2>/dev/null | sort', dir, size_filter))
+    if not handle then return files end
+    for line in handle:lines() do
+        files[#files + 1] = line
+    end
+    handle:close()
+    return files
+end
+
+-- ════════════════════════════════════════════════════════════════════
+-- Validation
+-- ════════════════════════════════════════════════════════════════════
+
+local function validate_lua_syntax(lua_source, source_name)
+    -- Try to load the Lua source as a chunk (syntax check only)
+    local chunk, err = load(lua_source, source_name)
+    if not chunk then
+        return false, "syntax error: " .. err
+    end
+    -- Execute to verify it returns a table
+    local ok, result = pcall(chunk)
+    if not ok then
+        return false, "runtime error: " .. tostring(result)
+    end
+    if type(result) ~= "table" then
+        return false, string.format("expected table return, got %s", type(result))
+    end
+    -- Verify required keys
+    if not result.scene then
+        return false, "missing 'scene' key in returned table"
+    end
+    return true, nil
+end
+
+-- ════════════════════════════════════════════════════════════════════
+-- Main
+-- ════════════════════════════════════════════════════════════════════
+
+local function main()
+    if #arg < 1 then
+        io.stderr:write("Usage: lua validate_roundtrip.lua <scenes_dir> [--roundtrip] [--verbose] [--stop-on-error] [--max-size=N]\n")
+        os.exit(1)
+    end
+
+    local scenes_dir = arg[1]
+    local do_roundtrip = false
+    local verbose = false
+    local stop_on_error = false
+    local max_size = nil
+
+    for i = 2, #arg do
+        if arg[i] == "--roundtrip" then do_roundtrip = true end
+        if arg[i] == "--verbose" then verbose = true end
+        if arg[i] == "--stop-on-error" then stop_on_error = true end
+        local sz = arg[i]:match("^%-%-max%-size=(%d+)$")
+        if sz then max_size = tonumber(sz) end
+    end
+
+    local files = find_pbrt_files(scenes_dir, max_size)
+    if #files == 0 then
+        io.stderr:write(string.format("No .pbrt files found under '%s'\n", scenes_dir))
+        os.exit(1)
+    end
+
+    io.stderr:write(string.format("Found %d .pbrt files\n", #files))
+
+    local pass = 0
+    local fail = 0
+    local skip = 0
+    local roundtrip_pass = 0
+    local roundtrip_fail = 0
+    local failures = {}
+
+    for i, filepath in ipairs(files) do
+        local short = filepath:sub(#scenes_dir + 1):gsub("^/", "")
+
+        -- Step 1: PBRT -> Lua
+        local result, parse_err = pbrt.parse_file(filepath)
+        if not result then
+            fail = fail + 1
+            local msg = string.format("[FAIL] %s: parse error: %s", short, parse_err or "unknown")
+            failures[#failures + 1] = msg
+            if verbose then io.stderr:write(msg .. "\n") end
+            if stop_on_error then break end
+        else
+            local lua_source = pbrt.to_lua(result)
+            local ok, err = validate_lua_syntax(lua_source, short)
+            if ok then
+                pass = pass + 1
+                if verbose then
+                    io.stderr:write(string.format("[PASS] %s (%d nodes, %d todos)\n",
+                        short, #result.scene, #result.todos))
+                end
+
+                -- Step 2: optional round-trip (Lua -> PBRT -> Lua)
+                if do_roundtrip then
+                    local pbrt_source = l2p.to_pbrt(result)
+                    local rt_result = pbrt.parse_source(pbrt_source)
+                    local rt_lua = pbrt.to_lua(rt_result)
+                    local rt_ok, rt_err = validate_lua_syntax(rt_lua, short .. " (roundtrip)")
+                    if rt_ok then
+                        roundtrip_pass = roundtrip_pass + 1
+                        if verbose then
+                            io.stderr:write(string.format("  [RT-PASS] %s\n", short))
+                        end
+                    else
+                        roundtrip_fail = roundtrip_fail + 1
+                        local msg = string.format("  [RT-FAIL] %s: %s", short, rt_err)
+                        failures[#failures + 1] = msg
+                        if verbose then io.stderr:write(msg .. "\n") end
+                        if stop_on_error then break end
+                    end
+                end
+            else
+                fail = fail + 1
+                local msg = string.format("[FAIL] %s: %s", short, err)
+                failures[#failures + 1] = msg
+                if verbose then io.stderr:write(msg .. "\n") end
+                if stop_on_error then break end
+            end
+        end
+
+        -- Progress indicator (every 50 files)
+        if not verbose and i % 50 == 0 then
+            io.stderr:write(string.format("  ... %d/%d\n", i, #files))
+        end
+    end
+
+    -- Summary
+    io.stderr:write("\n")
+    io.stderr:write(string.format("═══ Results ═══\n"))
+    io.stderr:write(string.format("  PBRT -> Lua:  %d pass, %d fail (of %d files)\n",
+        pass, fail, #files))
+    if do_roundtrip then
+        io.stderr:write(string.format("  Round-trip:   %d pass, %d fail\n",
+            roundtrip_pass, roundtrip_fail))
+    end
+
+    if #failures > 0 then
+        io.stderr:write(string.format("\n  Failures (%d):\n", #failures))
+        for _, msg in ipairs(failures) do
+            io.stderr:write("    " .. msg .. "\n")
+        end
+    end
+
+    os.exit(fail > 0 and 1 or 0)
+end
+
+if arg and arg[0] and arg[0]:match("validate_roundtrip%.lua$") then
+    main()
+end


### PR DESCRIPTION
## Summary

- Adds a Lua-based scene description system using sol2 bindings (new `lua` meson option, default off)
- Scene scripts return declarative tables that C++ parses into the existing scene graph — combining programmability (loops, functions, `require()`) with clean declarative syntax
- Includes `art-lua` CLI runner, 4 example scenes, and 13 test cases (37 assertions)
- Adds PBRT <-> Lua converter tools for importing real PBRT scene files

## New Components

| Component | Files |
|-----------|-------|
| **Lua bindings** | `src/lua/bind_{geometry,scene,camera,image,transform}.cpp`, `src/lua/bindings.cpp`, `src/lua/bind_internal.hpp` |
| **Scene loader** | `src/lua/scene_loader.cpp`, `include/art/lua/scene_loader.hpp` |
| **Scene serializer** | `src/lua/scene_serializer.cpp`, `include/art/lua/scene_serializer.hpp` |
| **CLI runner** | `src/art_lua.cpp` — `art-lua scene.lua [--output path] [--width N] [--height N] [--accel bvh\|linear]` |
| **Public API** | `include/art/lua/bindings.hpp` — `load_bindings()` |
| **Example scenes** | `scenes/{sphere,transforms,cornell_box,mesh_demo}.lua` |
| **Tests** | `tests/test_scene_loader.cpp` — 13 Catch2 test cases |
| **Build system** | `meson_options.txt` (`lua` option), `subprojects/sol2.wrap`, `subprojects/lua.wrap` |
| **PBRT tools** | `tools/pbrt_to_lua.lua`, `tools/lua_to_pbrt.lua`, `tools/validate_roundtrip.lua` |

## Scene DSL Format

```lua
return {
    render = { width = 800, height = 600, output = "scene.ppm", accelerator = "bvh" },
    camera = { position = {0,0,5}, target = {0,0,0}, up = {0,1,0} },
    scene = {
        { type = "sphere", transform = { translate = {1,0,0}, scale = 2 } },
        { type = "group", children = { { type = "box" }, { type = "disk" } } },
    },
}
```

## PBRT Converter Tools

Three standalone Lua modules under `tools/` (enabled via `meson -Dtools=true`, default on):

- **`pbrt_to_lua.lua`** — Parses PBRT v3/v4 scene files and converts to ART Lua table DSL. Handles all major directives (LookAt, Camera, Film, Shape, Transform, ObjectBegin/End, Include/Import). Supports gzipped Include files (.pbrt.gz). Unsupported features (materials, lights, textures) are consumed gracefully and emitted as TODO comments. Can be used as a module (`require("pbrt_to_lua")`) or CLI script.

- **`lua_to_pbrt.lua`** — Reverse converter from ART Lua scene tables to PBRT v3 format. Supports all ART geometry types with appropriate PBRT mappings.

- **`validate_roundtrip.lua`** — Batch validator for testing PBRT->Lua conversion across scene file directories. Supports `--max-size`, `--roundtrip`, `--verbose`, `--stop-on-error`, `--pbrt=<path>` flags.

### Validation Results

Full test corpus: 386 PBRT files (v3 + v4, under 5MB — files over 5MB are geometry fragments, not standalone scenes).

| Validation | Pass | Fail | Skipped |
|---|---|---|---|
| PBRT -> Lua syntax | **386** | 0 | 0 |
| pbrt --format verify | **370** | 0 | 16 |

The 16 skipped files are curve-heavy scenes (hair, bunny-fur) where placeholder spheres generate >50MB PBRT output. All 370 verified files produce PBRT output that the official pbrt-v4 binary accepts without error.

## Build & Test

```bash
git clone --depth=1 git@github.com:mtao/quiver.git subprojects/quiver  # required for wrap-redirect
meson setup build-debug --buildtype=debug -Dlua=true
meson compile -C build-debug
meson test -C build-debug -v
```

## Future Work

- PLY mesh loading via quiver I/O (currently emits placeholder sphere)
- Matrix transform support in ART's `parse_transform()` (preserved in Lua output)
- Material / light / texture support