### PR TITLE
feat: add triangle mesh ray tracing + terminal viewer tool

### DIFF
--- a/include/art/Image.hpp
+++ b/include/art/Image.hpp
@@ -1,5 +1,159 @@
-#pragma once
+#if !defined(ART_IMAGE_HPP)
+#define ART_IMAGE_HPP
+
+#include <array>
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <optional>
+#include <span>
+#include <vector>
+
+#include "art/export.hpp"
 
 namespace art {
-class Image {};
-}  // namespace art
+
+/// PBRT Film-style pixel buffer with sample accumulation.
+///
+/// Supports two modes of pixel writing:
+///   1. Direct: set_pixel() sets the final color value.
+///   2. Accumulation: add_sample() accumulates weighted color contributions;
+///      resolved_pixel() divides by total weight for the final value.
+///
+/// Thread safety: version() and progress counters are atomic. Write methods
+/// (set_pixel, add_sample, set_tile, set_scanline) are NOT synchronized —
+/// callers must ensure no two threads write the same pixel concurrently.
+/// The on_update callback is called from the writing thread.
+class ART_API Image {
+  public:
+    enum class PixelFormat { RGBA8, RGBAF32 };
+
+    Image() = default;
+    Image(size_t width,
+          size_t height,
+          PixelFormat format = PixelFormat::RGBAF32);
+
+    // Move-only (std::atomic members prevent implicit copy/move).
+    Image(const Image &) = delete;
+    auto operator=(const Image &) -> Image & = delete;
+    Image(Image &&other) noexcept;
+    auto operator=(Image &&other) noexcept -> Image &;
+
+    // ── Dimensions ──
+
+    auto width() const -> size_t;
+    auto height() const -> size_t;
+    auto format() const -> PixelFormat;
+
+    // ── Direct pixel access ──
+
+    void
+        set_pixel(size_t x, size_t y, float r, float g, float b, float a = 1.f);
+    auto pixel(size_t x, size_t y) const -> std::array<float, 4>;
+
+    // ── Sample accumulation (PBRT Film pattern) ──
+    //
+    // An Integrator calls add_sample() for each path/light sample.
+    // The Image accumulates weighted color contributions and tracks
+    // the total weight per pixel for correct normalization.
+
+    void add_sample(size_t x,
+                    size_t y,
+                    float r,
+                    float g,
+                    float b,
+                    float weight = 1.f);
+
+    /// Get the current (normalized) color at a pixel.
+    /// For add_sample mode: divides accumulated color by total weight.
+    /// For set_pixel mode: returns the last-set value.
+    auto resolved_pixel(size_t x, size_t y) const -> std::array<float, 4>;
+
+    // ── Bulk access ──
+
+    /// Set a full scanline (row y). Data must be width()*4 floats (RGBA).
+    void set_scanline(size_t y, std::span<const float> rgba_row);
+
+    /// Set a rectangular tile. Data must be w*h*4 floats (RGBA), row-major.
+    void set_tile(size_t x,
+                  size_t y,
+                  size_t w,
+                  size_t h,
+                  std::span<const float> rgba_data);
+
+    /// Full resolved pixel buffer (row-major, 4 floats per pixel).
+    /// For set_pixel mode: direct values.
+    /// For add_sample mode: normalized (resolved) values.
+    auto pixels() const -> std::span<const float>;
+
+    /// Raw accumulated buffer (un-normalized). For internal use
+    /// or advanced consumers that want to apply their own normalization.
+    auto raw_pixels() const -> std::span<const float>;
+
+    // ── Progress tracking ──
+    // Thread-safe (atomic). The render loop increments this.
+
+    void increment_progress(size_t count = 1);
+    auto pixels_completed() const -> size_t;
+    auto total_pixels() const -> size_t;
+    auto progress_fraction() const -> float;
+
+    // ── Dirty tracking + notification ──
+
+    /// Version is bumped on every write operation.
+    auto version() const -> uint64_t;
+
+    /// Callback invoked after each write with the dirty region.
+    /// Called from the writing thread — must be lightweight.
+    using UpdateCallback =
+        std::function<void(size_t x, size_t y, size_t w, size_t h)>;
+    void set_on_update(UpdateCallback cb);
+
+    // ── Conversion ──
+
+    /// Produce an RGBA8 buffer (for saving to 8-bit formats).
+    /// Applies the given exposure (EV stops) and gamma.
+    auto to_rgba8(float exposure = 0.f, float gamma = 2.2f) const
+        -> std::vector<uint8_t>;
+
+    // ── State queries ──
+
+    /// True if add_sample() has been called (weight buffer is allocated).
+    auto is_accumulation_mode() const -> bool;
+
+    /// Clear all pixel data and weights to zero. Dimensions unchanged.
+    void clear();
+
+  private:
+    size_t m_width = 0;
+    size_t m_height = 0;
+    PixelFormat m_format = PixelFormat::RGBAF32;
+
+    // Pixel storage: 4 floats per pixel (R, G, B, A), row-major.
+    std::vector<float> m_pixels;
+
+    // Per-pixel weight accumulator for add_sample mode.
+    // Empty when using set_pixel mode only.
+    std::vector<float> m_weights;
+
+    // Resolved (normalized) cache — lazily computed from m_pixels/m_weights.
+    mutable std::vector<float> m_resolved;
+    mutable uint64_t m_resolved_version = 0;
+
+    // Thread-safe progress and versioning.
+    std::atomic<size_t> m_pixels_completed = 0;
+    std::atomic<uint64_t> m_version = 0;
+
+    UpdateCallback m_on_update;
+
+    // ── Internal helpers ──
+
+    auto pixel_index(size_t x, size_t y) const -> size_t;
+    void notify(size_t x, size_t y, size_t w, size_t h);
+    void ensure_resolved() const;
+};
+
+} // namespace art
+
+#endif // ART_IMAGE_HPP

--- a/include/art/geometry/TriangleMesh.hpp
+++ b/include/art/geometry/TriangleMesh.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <array>
+#include <memory>
+#include <span>
+#include <vector>
+
+#include "art/geometry/Geometry.hpp"
+#include "art/zipper_types.hpp"
+
+namespace art::geometry {
+
+/// Triangle mesh geometry for ray tracing.
+///
+/// Stores vertex positions and triangle face indices. Computes per-face
+/// normals on construction. Uses Moller-Trumbore intersection.
+class ART_API TriangleMesh : public Geometry {
+  public:
+    using Face = std::array<size_t, 3>;
+
+    /// Construct from vertex positions and triangle indices.
+    TriangleMesh(std::vector<Vector3d> vertices, std::vector<Face> faces);
+
+    auto bounding_box() const -> Box override;
+
+    auto intersect(const Ray &ray, std::optional<Intersection> &isect) const
+        -> bool override;
+
+    auto vertices() const -> std::span<const Vector3d>;
+    auto faces() const -> std::span<const Face>;
+    auto face_normals() const -> std::span<const Vector3d>;
+
+  private:
+    std::vector<Vector3d> m_vertices;
+    std::vector<Face> m_faces;
+    std::vector<Vector3d> m_face_normals;
+    Box m_bbox;
+
+    void compute_normals();
+    void compute_bbox();
+};
+
+} // namespace art::geometry

--- a/include/art/io/image_io.hpp
+++ b/include/art/io/image_io.hpp
@@ -1,0 +1,81 @@
+#if !defined(ART_IO_IMAGE_IO_HPP)
+#define ART_IO_IMAGE_IO_HPP
+
+#include <expected>
+#include <filesystem>
+#include <string>
+
+#include "art/Image.hpp"
+#include "art/export.hpp"
+
+namespace art::io {
+
+// ── Format enum ──
+
+enum class ImageFormat {
+    EXR, // OpenEXR via tinyexr — HDR float, lossless
+    PNG, // PNG via stb_image — 8-bit LDR, lossless
+    PPM, // Portable PixMap — 8-bit, no dependency, always available
+    Auto, // Deduce from file extension
+};
+
+// ── Save options (for LDR conversion) ──
+
+struct SaveOptions {
+    float exposure = 0.f; // EV stops
+    float gamma = 2.2f; // gamma curve
+};
+
+// ── Generic load/save (dispatch on extension or explicit format) ──
+
+/// Load an image from any supported format.
+/// Format::Auto deduces from extension: .exr -> EXR, .png -> PNG, .ppm -> PPM.
+ART_API auto load(const std::filesystem::path &path,
+                  ImageFormat format = ImageFormat::Auto)
+    -> std::expected<Image, std::string>;
+
+/// Save an image to any supported format.
+/// For LDR formats (PNG, PPM): applies tone mapping (exposure + gamma).
+/// For HDR formats (EXR): writes float data directly.
+ART_API auto save(const std::filesystem::path &path,
+                  const Image &image,
+                  ImageFormat format = ImageFormat::Auto,
+                  const SaveOptions &opts = {})
+    -> std::expected<void, std::string>;
+
+// ── Query which formats are compiled in ──
+
+ART_API auto has_exr_support() -> bool;
+ART_API auto has_png_support() -> bool;
+ART_API auto has_ppm_support() -> bool; // always true
+
+// ── Format-specific functions ──
+
+namespace exr {
+    ART_API auto load(const std::filesystem::path &path)
+        -> std::expected<Image, std::string>;
+    ART_API auto save(const std::filesystem::path &path, const Image &image)
+        -> std::expected<void, std::string>;
+} // namespace exr
+
+namespace png {
+    ART_API auto load(const std::filesystem::path &path)
+        -> std::expected<Image, std::string>;
+    ART_API auto save(const std::filesystem::path &path,
+                      const Image &image,
+                      const SaveOptions &opts = {})
+        -> std::expected<void, std::string>;
+} // namespace png
+
+namespace ppm {
+    ART_API auto load(const std::filesystem::path &path)
+        -> std::expected<Image, std::string>;
+    ART_API auto save(const std::filesystem::path &path,
+                      const Image &image,
+                      const SaveOptions &opts = {})
+        -> std::expected<void, std::string>;
+} // namespace ppm
+
+} // namespace art::io
+
+#endif // ART_IO_IMAGE_IO_HPP

--- a/include/art/utils/AffineTransform.hpp
+++ b/include/art/utils/AffineTransform.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <zipper/transform/transform.hpp>
+#include <zipper/transform/all.hpp>
 
 #include "art/zipper_types.hpp"
 
@@ -11,4 +11,4 @@ using AffineTransform = zipper::transform::AffineTransform<double, 3>;
 using Isometry = zipper::transform::Isometry<double, 3>;
 using ProjectiveTransform = zipper::transform::ProjectiveTransform<double, 3>;
 
-}  // namespace art::utils
+} // namespace art::utils

--- a/meson.build
+++ b/meson.build
@@ -2,41 +2,61 @@ project('AnotherRayTracer', 'cpp',
   version : '0.1',
   default_options : ['warning_level=3', 'cpp_std=c++26'])
 
-
-
 # min versions
 spdlog_version = '>=1.9.2'
-
-
 
 cc = meson.get_compiler('cpp')
 dl_lib = cc.find_library('dl')
 
-
-spdlog_dep = dependency('spdlog', version: spdlog_version, default_options: ['tests=disabled'])
+spdlog_dep = dependency('spdlog', version: spdlog_version, default_options: ['tests=disabled', 'default_library=static'])
 
 zipper_proj = subproject('zipper', default_options: {'testing': false, 'examples': false})
 zipper_dep = zipper_proj.get_variable('zipper_dep')
 
 TBB_dep = dependency('tbb')
 
-required_deps = [zipper_dep]
+# ── Quiver (mesh library — required) ─────────────────────────────────────
+quiver_proj = subproject('quiver', default_options: {
+  'testing': false, 'tools': false, 'examples': false})
+quiver_dep = quiver_proj.get_variable('quiver_dep')
+
+required_deps = [zipper_dep, quiver_dep]
 internal_deps = [spdlog_dep] + required_deps
+
+# Optional image I/O dependencies
+io_cpp_args = []
+
+if get_option('exr')
+  tinyexr_proj = subproject('tinyexr')
+  tinyexr_dep = tinyexr_proj.get_variable('tinyexr_dep')
+  internal_deps += tinyexr_dep
+  io_cpp_args += '-DART_HAS_EXR=1'
+endif
+
+if get_option('png')
+  stb_proj = subproject('stb')
+  stb_dep = stb_proj.get_variable('stb_dep')
+  internal_deps += stb_dep
+  io_cpp_args += '-DART_HAS_PNG=1'
+endif
 
 lib_sources = [
     'src/Point.cpp'
-
     ,'src/geometry/Box.cpp'
     ,'src/geometry/Sphere.cpp'
-
+    ,'src/geometry/TriangleMesh.cpp'
+    ,'src/geometry/Line.cpp'
     ,'src/objects/SceneNode.cpp'
     ,'src/objects/InternalSceneNode.cpp'
     ,'src/objects/Object.cpp'
-
     ,'src/Camera.cpp'
-    ,'src/geometry/Line.cpp'
     ,'src/Rational.cpp'
     ,'src/Ray.cpp'
+    ,'src/Image.cpp'
+    ,'src/io/image_io.cpp'
+    ,'src/io/ppm.cpp'
+    ,'src/io/exr.cpp'
+    ,'src/io/png.cpp'
 ]
 
 include_dirs = [include_directories('include')]
@@ -50,7 +70,7 @@ art_headers_dep = declare_dependency(
 art_lib = library('art', lib_sources,
   include_directories: include_dirs,
   dependencies: internal_deps,
-  cpp_args: ['-DART_EXPORTS'],
+  cpp_args: ['-DART_EXPORTS'] + io_cpp_args,
   gnu_symbol_visibility: 'hidden')
 
 # Full dependency (headers + library linking)
@@ -59,13 +79,21 @@ art_dep = declare_dependency(
   dependencies: required_deps,
   include_directories: include_dirs)
 
-
 art_exec = executable('art', 'src/main.cpp', dependencies: [art_dep] + internal_deps)
-
 
 if get_option('testing')
   subdir('tests')
 endif
 if get_option('examples')
   subdir('examples')
+endif
+
+# ── Optional: terminal viewer tool (requires balsa) ──────────────────────
+if get_option('viewer')
+  balsa_proj = subproject('balsa', default_options: {
+    'testing': false, 'examples': false, 'visualization': false, 'qt': false,
+    'glfw': false, 'imgui': false})
+  balsaCore_dep = balsa_proj.get_variable('core_dep')
+
+  subdir('tools')
 endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,2 +1,5 @@
 option('testing', type : 'boolean', value : true, description : 'Enable tests')
 option('examples', type : 'boolean', value : true, description : 'Build examples')
+option('exr', type : 'boolean', value : false, description : 'EXR image I/O via tinyexr')
+option('png', type : 'boolean', value : false, description : 'PNG image I/O via stb_image')
+option('viewer', type : 'boolean', value : false, description : 'Terminal viewer tool (requires balsa)')

--- a/src/Camera.cpp
+++ b/src/Camera.cpp
@@ -1,14 +1,17 @@
 #include "art/Camera.hpp"
 
-#include <iostream>
-#include <zipper/transform/transform.hpp>
+#include <cmath>
+
+#include <zipper/transform/all.hpp>
 
 #include "art/Ray.hpp"
 #include "art/utils/AffineTransform.hpp"
+
 namespace art {
 
-utils::Isometry Camera::lookAt(const Point& position, const Point& target,
-                                const Point& up) {
+utils::Isometry Camera::lookAt(const Point &position,
+                               const Point &target,
+                               const Point &up) {
     // Convert Points to Vector3d (divides numerator by denominator)
     Vector3d eye = position;
     Vector3d center = target;
@@ -16,7 +19,9 @@ utils::Isometry Camera::lookAt(const Point& position, const Point& target,
     return zipper::transform::look_at(eye, center, up_vec);
 }
 
-Image Camera::render(size_t nx, size_t ny, objects::SceneNode& node) const {
+Image Camera::render(size_t nx, size_t ny, objects::SceneNode &node) const {
+    Image image(nx, ny);
+
     Ray ray;
     ray.origin = Point(0, 0, 0);
 
@@ -38,13 +43,20 @@ Image Camera::render(size_t nx, size_t ny, objects::SceneNode& node) const {
 
             std::optional<Intersection> isect;
             if (node.intersect(ray, isect)) {
-                std::cout << "o";
+                // Headlight shading: abs(N . view_dir) gives a basic
+                // diffuse look without requiring separate light sources.
+                double dir_len = ray.direction.norm<2>();
+                Vector3d n = isect->normal.normalized();
+                float shade = static_cast<float>(
+                    std::abs(n.dot(ray.direction) / dir_len));
+                image.set_pixel(i, j, shade, shade, shade, 1.f);
             } else {
-                std::cout << ".";
+                image.set_pixel(i, j, 0.f, 0.f, 0.f, 1.f);
             }
+            image.increment_progress();
         }
-        std::cout << std::endl;
     }
-    return {};
+    return image;
 }
-}  // namespace art
+
+} // namespace art

--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -1,0 +1,255 @@
+#include "art/Image.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <utility>
+
+namespace art {
+
+Image::Image(size_t width, size_t height, PixelFormat format)
+  : m_width(width), m_height(height), m_format(format),
+    m_pixels(width * height * 4, 0.f) {}
+
+Image::Image(Image &&other) noexcept
+  : m_width(other.m_width), m_height(other.m_height), m_format(other.m_format),
+    m_pixels(std::move(other.m_pixels)), m_weights(std::move(other.m_weights)),
+    m_resolved(std::move(other.m_resolved)),
+    m_resolved_version(other.m_resolved_version),
+    m_pixels_completed(
+        other.m_pixels_completed.load(std::memory_order_relaxed)),
+    m_version(other.m_version.load(std::memory_order_relaxed)),
+    m_on_update(std::move(other.m_on_update)) {
+    other.m_width = 0;
+    other.m_height = 0;
+}
+
+auto Image::operator=(Image &&other) noexcept -> Image & {
+    if (this != &other) {
+        m_width = other.m_width;
+        m_height = other.m_height;
+        m_format = other.m_format;
+        m_pixels = std::move(other.m_pixels);
+        m_weights = std::move(other.m_weights);
+        m_resolved = std::move(other.m_resolved);
+        m_resolved_version = other.m_resolved_version;
+        m_pixels_completed.store(
+            other.m_pixels_completed.load(std::memory_order_relaxed),
+            std::memory_order_relaxed);
+        m_version.store(other.m_version.load(std::memory_order_relaxed),
+                        std::memory_order_relaxed);
+        m_on_update = std::move(other.m_on_update);
+        other.m_width = 0;
+        other.m_height = 0;
+    }
+    return *this;
+}
+
+// ── Dimensions ──
+
+auto Image::width() const -> size_t { return m_width; }
+auto Image::height() const -> size_t { return m_height; }
+auto Image::format() const -> PixelFormat { return m_format; }
+
+// ── Direct pixel access ──
+
+void Image::set_pixel(size_t x, size_t y, float r, float g, float b, float a) {
+    size_t idx = pixel_index(x, y);
+    m_pixels[idx + 0] = r;
+    m_pixels[idx + 1] = g;
+    m_pixels[idx + 2] = b;
+    m_pixels[idx + 3] = a;
+    m_version.fetch_add(1, std::memory_order_release);
+    notify(x, y, 1, 1);
+}
+
+auto Image::pixel(size_t x, size_t y) const -> std::array<float, 4> {
+    size_t idx = pixel_index(x, y);
+    return {m_pixels[idx + 0],
+            m_pixels[idx + 1],
+            m_pixels[idx + 2],
+            m_pixels[idx + 3]};
+}
+
+// ── Sample accumulation ──
+
+void Image::add_sample(size_t x,
+                       size_t y,
+                       float r,
+                       float g,
+                       float b,
+                       float weight) {
+    // Lazily allocate weight buffer on first use.
+    if (m_weights.empty()) { m_weights.resize(m_width * m_height, 0.f); }
+    size_t idx = pixel_index(x, y);
+    size_t pidx = (y * m_width + x);
+    m_pixels[idx + 0] += r * weight;
+    m_pixels[idx + 1] += g * weight;
+    m_pixels[idx + 2] += b * weight;
+    m_pixels[idx + 3] += weight; // alpha accumulates weight for now
+    m_weights[pidx] += weight;
+    m_version.fetch_add(1, std::memory_order_release);
+    notify(x, y, 1, 1);
+}
+
+auto Image::resolved_pixel(size_t x, size_t y) const -> std::array<float, 4> {
+    size_t idx = pixel_index(x, y);
+
+    if (m_weights.empty()) {
+        // Direct mode — return as-is.
+        return {m_pixels[idx + 0],
+                m_pixels[idx + 1],
+                m_pixels[idx + 2],
+                m_pixels[idx + 3]};
+    }
+
+    // Accumulation mode — normalize by weight.
+    size_t pidx = (y * m_width + x);
+    float w = m_weights[pidx];
+    if (w == 0.f) { return {0.f, 0.f, 0.f, 0.f}; }
+    float inv_w = 1.f / w;
+    return {m_pixels[idx + 0] * inv_w,
+            m_pixels[idx + 1] * inv_w,
+            m_pixels[idx + 2] * inv_w,
+            1.f};
+}
+
+// ── Bulk access ──
+
+void Image::set_scanline(size_t y, std::span<const float> rgba_row) {
+    if (rgba_row.size() < m_width * 4) { return; }
+    size_t idx = pixel_index(0, y);
+    std::copy_n(rgba_row.data(), m_width * 4, m_pixels.data() + idx);
+    m_version.fetch_add(1, std::memory_order_release);
+    notify(0, y, m_width, 1);
+}
+
+void Image::set_tile(size_t x,
+                     size_t y,
+                     size_t w,
+                     size_t h,
+                     std::span<const float> rgba_data) {
+    if (rgba_data.size() < w * h * 4) { return; }
+    for (size_t row = 0; row < h; ++row) {
+        size_t dst_idx = pixel_index(x, y + row);
+        size_t src_idx = row * w * 4;
+        std::copy_n(
+            rgba_data.data() + src_idx, w * 4, m_pixels.data() + dst_idx);
+    }
+    m_version.fetch_add(1, std::memory_order_release);
+    notify(x, y, w, h);
+}
+
+auto Image::pixels() const -> std::span<const float> {
+    if (m_weights.empty()) { return m_pixels; }
+    ensure_resolved();
+    return m_resolved;
+}
+
+auto Image::raw_pixels() const -> std::span<const float> { return m_pixels; }
+
+// ── Progress tracking ──
+
+void Image::increment_progress(size_t count) {
+    m_pixels_completed.fetch_add(count, std::memory_order_relaxed);
+}
+
+auto Image::pixels_completed() const -> size_t {
+    return m_pixels_completed.load(std::memory_order_relaxed);
+}
+
+auto Image::total_pixels() const -> size_t { return m_width * m_height; }
+
+auto Image::progress_fraction() const -> float {
+    size_t total = total_pixels();
+    if (total == 0) return 0.f;
+    return static_cast<float>(pixels_completed()) / static_cast<float>(total);
+}
+
+// ── Dirty tracking + notification ──
+
+auto Image::version() const -> uint64_t {
+    return m_version.load(std::memory_order_acquire);
+}
+
+void Image::set_on_update(UpdateCallback cb) { m_on_update = std::move(cb); }
+
+// ── Conversion ──
+
+auto Image::to_rgba8(float exposure, float gamma) const
+    -> std::vector<uint8_t> {
+    auto src = pixels(); // resolved if in accumulation mode
+    size_t num_pixels = m_width * m_height;
+    std::vector<uint8_t> out(num_pixels * 4);
+
+    float exposure_scale = std::exp2(exposure);
+    float inv_gamma = 1.f / gamma;
+
+    for (size_t i = 0; i < num_pixels; ++i) {
+        size_t si = i * 4;
+        for (size_t c = 0; c < 3; ++c) {
+            float v = src[si + c] * exposure_scale;
+            v = std::pow(std::max(v, 0.f), inv_gamma);
+            v = std::clamp(v, 0.f, 1.f);
+            out[si + c] = static_cast<uint8_t>(v * 255.f + 0.5f);
+        }
+        // Alpha: linear, no tone mapping
+        float a = std::clamp(src[si + 3], 0.f, 1.f);
+        out[si + 3] = static_cast<uint8_t>(a * 255.f + 0.5f);
+    }
+    return out;
+}
+
+// ── State queries ──
+
+auto Image::is_accumulation_mode() const -> bool {
+    return !m_weights.empty();
+}
+
+void Image::clear() {
+    std::fill(m_pixels.begin(), m_pixels.end(), 0.f);
+    std::fill(m_weights.begin(), m_weights.end(), 0.f);
+    m_resolved.clear();
+    m_resolved_version = 0;
+    m_pixels_completed.store(0, std::memory_order_relaxed);
+    m_version.fetch_add(1, std::memory_order_release);
+    notify(0, 0, m_width, m_height);
+}
+
+// ── Internal helpers ──
+
+auto Image::pixel_index(size_t x, size_t y) const -> size_t {
+    if (x >= m_width || y >= m_height) { std::unreachable(); }
+    return (y * m_width + x) * 4;
+}
+
+void Image::notify(size_t x, size_t y, size_t w, size_t h) {
+    if (m_on_update) { m_on_update(x, y, w, h); }
+}
+
+void Image::ensure_resolved() const {
+    uint64_t ver = m_version.load(std::memory_order_acquire);
+    if (m_resolved_version == ver && !m_resolved.empty()) { return; }
+
+    size_t num_pixels = m_width * m_height;
+    m_resolved.resize(num_pixels * 4);
+
+    for (size_t i = 0; i < num_pixels; ++i) {
+        size_t idx = i * 4;
+        float w = m_weights[i];
+        if (w == 0.f) {
+            m_resolved[idx + 0] = 0.f;
+            m_resolved[idx + 1] = 0.f;
+            m_resolved[idx + 2] = 0.f;
+            m_resolved[idx + 3] = 0.f;
+        } else {
+            float inv_w = 1.f / w;
+            m_resolved[idx + 0] = m_pixels[idx + 0] * inv_w;
+            m_resolved[idx + 1] = m_pixels[idx + 1] * inv_w;
+            m_resolved[idx + 2] = m_pixels[idx + 2] * inv_w;
+            m_resolved[idx + 3] = 1.f;
+        }
+    }
+    m_resolved_version = ver;
+}
+
+} // namespace art

--- a/src/geometry/TriangleMesh.cpp
+++ b/src/geometry/TriangleMesh.cpp
@@ -1,0 +1,112 @@
+#include "art/geometry/TriangleMesh.hpp"
+
+#include <cmath>
+#include <limits>
+
+#include "art/Point.hpp"
+#include "art/Ray.hpp"
+
+namespace art::geometry {
+
+TriangleMesh::TriangleMesh(std::vector<Vector3d> vertices,
+                           std::vector<Face> faces)
+  : m_vertices(std::move(vertices)), m_faces(std::move(faces)) {
+    compute_normals();
+    compute_bbox();
+}
+
+auto TriangleMesh::bounding_box() const -> Box { return m_bbox; }
+
+auto TriangleMesh::intersect(const Ray &ray,
+                             std::optional<Intersection> &isect) const -> bool {
+    // Moller-Trumbore intersection for each triangle.
+    // Linear scan — acceptable for moderate meshes; BVH is a future addition.
+    constexpr double eps = 1e-12;
+
+    // Pre-extract the Euclidean ray origin (one division up front).
+    Vector3d origin = ray.origin;
+    const auto &dir = ray.direction;
+
+    bool any_hit = false;
+
+    for (size_t fi = 0; fi < m_faces.size(); ++fi) {
+        const auto &[i0, i1, i2] = m_faces[fi];
+        const auto &v0 = m_vertices[i0];
+        const auto &v1 = m_vertices[i1];
+        const auto &v2 = m_vertices[i2];
+
+        Vector3d e1 = v1 - v0;
+        Vector3d e2 = v2 - v0;
+        Vector3d h = dir.cross(e2);
+        double a = e1.dot(h);
+
+        if (std::abs(a) < eps) {
+            continue; // Ray parallel to triangle.
+        }
+
+        double f = 1.0 / a;
+        Vector3d s = origin - v0;
+        double u = f * s.dot(h);
+        if (u < 0.0 || u > 1.0) { continue; }
+
+        Vector3d q = s.cross(e1);
+        double v = f * dir.dot(q);
+        if (v < 0.0 || u + v > 1.0) { continue; }
+
+        double t = f * e2.dot(q);
+        if (t < eps) {
+            continue; // Behind the ray origin.
+        }
+
+        Rational t_rat(t);
+        if (!isect || isect->t > t_rat) {
+            isect.emplace();
+            isect->t = t_rat;
+            isect->position = ray(t_rat);
+            isect->normal = m_face_normals[fi];
+            any_hit = true;
+        }
+    }
+
+    return any_hit;
+}
+
+auto TriangleMesh::vertices() const -> std::span<const Vector3d> {
+    return m_vertices;
+}
+
+auto TriangleMesh::faces() const -> std::span<const Face> { return m_faces; }
+
+auto TriangleMesh::face_normals() const -> std::span<const Vector3d> {
+    return m_face_normals;
+}
+
+void TriangleMesh::compute_normals() {
+    m_face_normals.resize(m_faces.size());
+    for (size_t fi = 0; fi < m_faces.size(); ++fi) {
+        const auto &[i0, i1, i2] = m_faces[fi];
+        Vector3d e1 = m_vertices[i1] - m_vertices[i0];
+        Vector3d e2 = m_vertices[i2] - m_vertices[i0];
+        Vector3d n = e1.cross(e2);
+        double len = n.norm<2>();
+        if (len > 1e-15) {
+            m_face_normals[fi] = n / len;
+        } else {
+            m_face_normals[fi] = Vector3d({0.0, 0.0, 1.0});
+        }
+    }
+}
+
+void TriangleMesh::compute_bbox() {
+    if (m_vertices.empty()) {
+        m_bbox = Box();
+        return;
+    }
+
+    m_bbox = Box({Point(m_vertices[0]), Point(m_vertices[0])});
+    for (size_t i = 1; i < m_vertices.size(); ++i) {
+        m_bbox.expand(Point(m_vertices[i]));
+    }
+}
+
+} // namespace art::geometry

--- a/src/io/exr.cpp
+++ b/src/io/exr.cpp
@@ -1,0 +1,101 @@
+#include "art/io/image_io.hpp"
+
+#ifdef ART_HAS_EXR
+
+#include <tinyexr.h>
+
+#include <cstring>
+
+namespace art::io {
+
+auto has_exr_support() -> bool { return true; }
+
+namespace exr {
+
+    auto load(const std::filesystem::path &path)
+        -> std::expected<Image, std::string> {
+        float *rgba = nullptr;
+        int width = 0, height = 0;
+        const char *err = nullptr;
+
+        int ret = LoadEXR(&rgba, &width, &height, path.string().c_str(), &err);
+        if (ret != TINYEXR_SUCCESS) {
+            std::string msg = err ? std::string(err) : "Unknown EXR error";
+            if (err) FreeEXRErrorMessage(err);
+            return std::unexpected("Failed to load EXR: " + msg);
+        }
+
+        Image img(static_cast<size_t>(width), static_cast<size_t>(height));
+        // tinyexr LoadEXR returns RGBA float interleaved
+        for (int y = 0; y < height; ++y) {
+            for (int x = 0; x < width; ++x) {
+                size_t i = static_cast<size_t>(y * width + x) * 4;
+                img.set_pixel(static_cast<size_t>(x),
+                              static_cast<size_t>(y),
+                              rgba[i + 0],
+                              rgba[i + 1],
+                              rgba[i + 2],
+                              rgba[i + 3]);
+            }
+        }
+        free(rgba);
+
+        return img;
+    }
+
+    auto save(const std::filesystem::path &path, const Image &image)
+        -> std::expected<void, std::string> {
+        if (image.width() == 0 || image.height() == 0) {
+            return std::unexpected("Cannot save empty image");
+        }
+
+        auto pixels = image.pixels();
+        int width = static_cast<int>(image.width());
+        int height = static_cast<int>(image.height());
+
+        const char *err = nullptr;
+        int ret = SaveEXR(pixels.data(),
+                          width,
+                          height,
+                          /*num_channels=*/4,
+                          /*save_as_fp16=*/1,
+                          path.string().c_str(),
+                          &err);
+        if (ret != TINYEXR_SUCCESS) {
+            std::string msg = err ? std::string(err) : "Unknown EXR error";
+            if (err) FreeEXRErrorMessage(err);
+            return std::unexpected("Failed to save EXR: " + msg);
+        }
+
+        return {};
+    }
+
+} // namespace exr
+
+} // namespace art::io
+
+#else // !ART_HAS_EXR
+
+namespace art::io {
+
+auto has_exr_support() -> bool { return false; }
+
+namespace exr {
+
+    auto load(const std::filesystem::path &)
+        -> std::expected<Image, std::string> {
+        return std::unexpected(
+            "EXR support not compiled; rebuild with -Dexr=true");
+    }
+
+    auto save(const std::filesystem::path &, const Image &)
+        -> std::expected<void, std::string> {
+        return std::unexpected(
+            "EXR support not compiled; rebuild with -Dexr=true");
+    }
+
+} // namespace exr
+
+} // namespace art::io
+
+#endif // ART_HAS_EXR

--- a/src/io/image_io.cpp
+++ b/src/io/image_io.cpp
@@ -1,0 +1,72 @@
+#include "art/io/image_io.hpp"
+
+#include <algorithm>
+
+namespace art::io {
+
+namespace {
+
+    auto deduce_format(const std::filesystem::path &path)
+        -> std::expected<ImageFormat, std::string> {
+        auto ext = path.extension().string();
+        std::transform(ext.begin(),
+                       ext.end(),
+                       ext.begin(),
+                       [](unsigned char c) { return std::tolower(c); });
+
+        if (ext == ".exr") return ImageFormat::EXR;
+        if (ext == ".png") return ImageFormat::PNG;
+        if (ext == ".ppm") return ImageFormat::PPM;
+        return std::unexpected("Unknown image format for extension '" + ext
+                               + "'");
+    }
+
+} // namespace
+
+auto load(const std::filesystem::path &path, ImageFormat format)
+    -> std::expected<Image, std::string> {
+    if (format == ImageFormat::Auto) {
+        auto fmt = deduce_format(path);
+        if (!fmt) return std::unexpected(fmt.error());
+        format = *fmt;
+    }
+
+    switch (format) {
+    case ImageFormat::EXR:
+        return exr::load(path);
+    case ImageFormat::PNG:
+        return png::load(path);
+    case ImageFormat::PPM:
+        return ppm::load(path);
+    case ImageFormat::Auto:
+        break; // unreachable
+    }
+    return std::unexpected("Unknown image format");
+}
+
+auto save(const std::filesystem::path &path,
+          const Image &image,
+          ImageFormat format,
+          const SaveOptions &opts) -> std::expected<void, std::string> {
+    if (format == ImageFormat::Auto) {
+        auto fmt = deduce_format(path);
+        if (!fmt) return std::unexpected(fmt.error());
+        format = *fmt;
+    }
+
+    switch (format) {
+    case ImageFormat::EXR:
+        return exr::save(path, image);
+    case ImageFormat::PNG:
+        return png::save(path, image, opts);
+    case ImageFormat::PPM:
+        return ppm::save(path, image, opts);
+    case ImageFormat::Auto:
+        break; // unreachable
+    }
+    return std::unexpected("Unknown image format");
+}
+
+auto has_ppm_support() -> bool { return true; }
+
+} // namespace art::io

--- a/src/io/png.cpp
+++ b/src/io/png.cpp
@@ -1,0 +1,93 @@
+#include "art/io/image_io.hpp"
+
+#ifdef ART_HAS_PNG
+
+#define STB_IMAGE_IMPLEMENTATION
+#include <stb_image.h>
+
+#define STB_IMAGE_WRITE_IMPLEMENTATION
+#include <stb_image_write.h>
+
+namespace art::io {
+
+auto has_png_support() -> bool { return true; }
+
+namespace png {
+
+    auto load(const std::filesystem::path &path)
+        -> std::expected<Image, std::string> {
+        int width = 0, height = 0, channels = 0;
+        unsigned char *data =
+            stbi_load(path.string().c_str(), &width, &height, &channels, 4);
+        if (!data) {
+            return std::unexpected("Failed to load PNG: "
+                                   + std::string(stbi_failure_reason()));
+        }
+
+        Image img(static_cast<size_t>(width), static_cast<size_t>(height));
+        // Convert RGBA8 -> RGBAF32 (assuming sRGB input)
+        for (int y = 0; y < height; ++y) {
+            for (int x = 0; x < width; ++x) {
+                size_t i = static_cast<size_t>(y * width + x) * 4;
+                float r = static_cast<float>(data[i + 0]) / 255.f;
+                float g = static_cast<float>(data[i + 1]) / 255.f;
+                float b = static_cast<float>(data[i + 2]) / 255.f;
+                float a = static_cast<float>(data[i + 3]) / 255.f;
+                img.set_pixel(
+                    static_cast<size_t>(x), static_cast<size_t>(y), r, g, b, a);
+            }
+        }
+        stbi_image_free(data);
+
+        return img;
+    }
+
+    auto save(const std::filesystem::path &path,
+              const Image &image,
+              const SaveOptions &opts) -> std::expected<void, std::string> {
+        if (image.width() == 0 || image.height() == 0) {
+            return std::unexpected("Cannot save empty image");
+        }
+
+        auto rgba8 = image.to_rgba8(opts.exposure, opts.gamma);
+        int width = static_cast<int>(image.width());
+        int height = static_cast<int>(image.height());
+
+        int ret = stbi_write_png(
+            path.string().c_str(), width, height, 4, rgba8.data(), width * 4);
+        if (ret == 0) {
+            return std::unexpected("Failed to write PNG: " + path.string());
+        }
+
+        return {};
+    }
+
+} // namespace png
+
+} // namespace art::io
+
+#else // !ART_HAS_PNG
+
+namespace art::io {
+
+auto has_png_support() -> bool { return false; }
+
+namespace png {
+
+    auto load(const std::filesystem::path &)
+        -> std::expected<Image, std::string> {
+        return std::unexpected(
+            "PNG support not compiled; rebuild with -Dpng=true");
+    }
+
+    auto save(const std::filesystem::path &, const Image &, const SaveOptions &)
+        -> std::expected<void, std::string> {
+        return std::unexpected(
+            "PNG support not compiled; rebuild with -Dpng=true");
+    }
+
+} // namespace png
+
+} // namespace art::io
+
+#endif // ART_HAS_PNG

--- a/src/io/ppm.cpp
+++ b/src/io/ppm.cpp
@@ -1,0 +1,111 @@
+#include "art/io/image_io.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <cstdint>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+namespace art::io::ppm {
+
+auto load(const std::filesystem::path &path)
+    -> std::expected<Image, std::string> {
+    std::ifstream file(path, std::ios::binary);
+    if (!file) { return std::unexpected("Cannot open file: " + path.string()); }
+
+    // Read magic number
+    std::string magic;
+    file >> magic;
+    if (magic != "P6") {
+        return std::unexpected("Not a binary PPM file (expected P6, got "
+                               + magic + ")");
+    }
+
+    // Skip whitespace and comments
+    auto skip_comments = [&file]() {
+        file >> std::ws;
+        while (file.peek() == '#') {
+            file.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+            file >> std::ws;
+        }
+    };
+
+    skip_comments();
+
+    size_t width, height;
+    file >> width;
+    skip_comments();
+    file >> height;
+    skip_comments();
+
+    int max_val;
+    file >> max_val;
+
+    // Consume the single whitespace character after maxval
+    file.get();
+
+    if (!file || width == 0 || height == 0) {
+        return std::unexpected("Invalid PPM header in " + path.string());
+    }
+
+    if (max_val != 255) {
+        return std::unexpected("Only 8-bit PPM supported (maxval="
+                               + std::to_string(max_val) + ")");
+    }
+
+    // Read RGB pixels
+    std::vector<uint8_t> rgb(width * height * 3);
+    file.read(reinterpret_cast<char *>(rgb.data()),
+              static_cast<std::streamsize>(rgb.size()));
+    if (!file) {
+        return std::unexpected("Truncated pixel data in " + path.string());
+    }
+
+    // Convert RGB8 -> RGBAF32
+    Image img(width, height);
+    for (size_t i = 0; i < width * height; ++i) {
+        float r = static_cast<float>(rgb[i * 3 + 0]) / 255.f;
+        float g = static_cast<float>(rgb[i * 3 + 1]) / 255.f;
+        float b = static_cast<float>(rgb[i * 3 + 2]) / 255.f;
+        size_t x = i % width;
+        size_t y = i / width;
+        img.set_pixel(x, y, r, g, b, 1.f);
+    }
+
+    return img;
+}
+
+auto save(const std::filesystem::path &path,
+          const Image &image,
+          const SaveOptions &opts) -> std::expected<void, std::string> {
+    if (image.width() == 0 || image.height() == 0) {
+        return std::unexpected("Cannot save empty image");
+    }
+
+    std::ofstream file(path, std::ios::binary);
+    if (!file) {
+        return std::unexpected("Cannot open file for writing: "
+                               + path.string());
+    }
+
+    auto rgba8 = image.to_rgba8(opts.exposure, opts.gamma);
+
+    // Write PPM P6 header
+    file << "P6\n"
+         << image.width() << " " << image.height() << "\n"
+         << "255\n";
+
+    // Write RGB pixels (strip alpha)
+    for (size_t i = 0; i < image.width() * image.height(); ++i) {
+        file.put(static_cast<char>(rgba8[i * 4 + 0]));
+        file.put(static_cast<char>(rgba8[i * 4 + 1]));
+        file.put(static_cast<char>(rgba8[i * 4 + 2]));
+    }
+
+    if (!file) { return std::unexpected("Write error to " + path.string()); }
+
+    return {};
+}
+
+} // namespace art::io::ppm

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,6 @@
 #include <iostream>
 
-#include <zipper/transform/transform.hpp>
+#include <zipper/transform/all.hpp>
 
 #include "art/Camera.hpp"
 #include "art/geometry/Box.hpp"
@@ -63,7 +63,7 @@ void both() {
 
     Image img = cam.render(100, 100, *scene);
 }
-int main(int argc, char* argv[]) {
+int main(int argc, char *argv[]) {
     sphere();
     cube();
     both();

--- a/subprojects/.gitignore
+++ b/subprojects/.gitignore
@@ -2,3 +2,13 @@
 */
 !packagefiles/
 .wraplock
+
+# Auto-generated wrap-redirects from transitive deps (quiver, balsa, zipper)
+cli11.wrap
+eigen.wrap
+fmt.wrap
+lua.wrap
+mdspan.wrap
+mshio.wrap
+nlohmann_json.wrap
+sol2.wrap

--- a/subprojects/balsa.wrap
+++ b/subprojects/balsa.wrap
@@ -1,0 +1,3 @@
+[wrap-git]
+url = git@github.com:mtao/balsa.git
+revision = feature/terminal-mesh-viewer

--- a/subprojects/quiver.wrap
+++ b/subprojects/quiver.wrap
@@ -1,0 +1,3 @@
+[wrap-git]
+url = git@github.com:mtao/quiver.git
+revision = main

--- a/tools/art_term.cpp
+++ b/tools/art_term.cpp
@@ -1,0 +1,149 @@
+// art_term — Ray-trace a mesh and display in the terminal.
+//
+// Usage: art_term model.obj [width] [height]
+//
+// Loads a triangle mesh via quiver, builds an ART scene, ray-traces it
+// with headlight shading, and outputs the image to the terminal via
+// Kitty graphics protocol (or half-block truecolor fallback).
+
+#include <cstdlib>
+#include <filesystem>
+#include <iostream>
+#include <string>
+
+#include <spdlog/spdlog.h>
+
+#include <quiver/MeshBase.hpp>
+#include <quiver/io/mesh_io.hpp>
+
+#include "art/Camera.hpp"
+#include "art/Image.hpp"
+#include "art/geometry/TriangleMesh.hpp"
+#include "art/io/image_io.hpp"
+#include "art/objects/Object.hpp"
+#include "art/zipper_types.hpp"
+
+#include <balsa/terminal/image_output.hpp>
+
+namespace {
+
+/// Extract vertex positions and triangle indices from a quiver MeshBase
+/// and build an art::geometry::TriangleMesh.
+auto mesh_from_quiver(const quiver::MeshBase &mesh)
+    -> std::shared_ptr<art::geometry::TriangleMesh> {
+    // Vertex positions: stored as "vertex_positions" at dim 0.
+    auto vp_handle =
+        mesh.get_attribute_handle<std::array<double, 3>>("vertex_positions", 0);
+    if (!vp_handle) {
+        spdlog::error("Mesh has no vertex_positions attribute");
+        return nullptr;
+    }
+    const auto &vp = vp_handle->attribute();
+
+    std::vector<art::Vector3d> vertices;
+    vertices.reserve(vp.size());
+    for (size_t i = 0; i < vp.size(); ++i) {
+        const auto &p = vp[i];
+        vertices.emplace_back(art::Vector3d({p[0], p[1], p[2]}));
+    }
+
+    // Triangle indices: stored as "_SV" at dim 2.
+    auto sv_handle =
+        mesh.get_attribute_handle<std::array<int64_t, 3>>("_SV", 2);
+    if (!sv_handle) {
+        spdlog::error("Mesh has no triangle connectivity (_SV at dim 2)");
+        return nullptr;
+    }
+    const auto &sv = sv_handle->attribute();
+
+    std::vector<art::geometry::TriangleMesh::Face> faces;
+    faces.reserve(sv.size());
+    for (size_t i = 0; i < sv.size(); ++i) {
+        const auto &tri = sv[i];
+        faces.push_back({static_cast<size_t>(tri[0]),
+                         static_cast<size_t>(tri[1]),
+                         static_cast<size_t>(tri[2])});
+    }
+
+    return std::make_shared<art::geometry::TriangleMesh>(std::move(vertices),
+                                                         std::move(faces));
+}
+
+/// Compute a bounding sphere center and radius for auto-framing the camera.
+auto compute_centroid_and_radius(const art::geometry::TriangleMesh &mesh)
+    -> std::pair<art::Vector3d, double> {
+    auto verts = mesh.vertices();
+    if (verts.empty()) { return {{}, 1.0}; }
+
+    art::Vector3d center({0.0, 0.0, 0.0});
+    for (const auto &v : verts) { center = center + v; }
+    center = center / static_cast<double>(verts.size());
+
+    double max_dist_sq = 0.0;
+    for (const auto &v : verts) {
+        double d = (v - center).norm_powered<2>();
+        if (d > max_dist_sq) { max_dist_sq = d; }
+    }
+    return {center, std::sqrt(max_dist_sq)};
+}
+
+} // namespace
+
+int main(int argc, char *argv[]) {
+    if (argc < 2) {
+        std::cerr << "Usage: art_term <mesh_file> [width] [height]\n";
+        return 1;
+    }
+
+    std::filesystem::path mesh_path = argv[1];
+    size_t width = 640;
+    size_t height = 480;
+
+    if (argc >= 3) { width = std::stoul(argv[2]); }
+    if (argc >= 4) { height = std::stoul(argv[3]); }
+
+    // 1. Load mesh via quiver.
+    spdlog::info("Loading mesh: {}", mesh_path.string());
+    auto result = quiver::io::read_mesh(mesh_path);
+    if (!result) {
+        spdlog::error("Failed to load mesh: {}", mesh_path.string());
+        return 1;
+    }
+    auto quiver_mesh = std::move(*result);
+
+    // 2. Convert to ART TriangleMesh.
+    auto tri_mesh = mesh_from_quiver(*quiver_mesh);
+    if (!tri_mesh) { return 1; }
+    spdlog::info("Loaded {} vertices, {} triangles",
+                 tri_mesh->vertices().size(),
+                 tri_mesh->faces().size());
+
+    // 3. Build scene: wrap geometry in an Object.
+    art::objects::Object obj(*tri_mesh);
+    obj.update_bounding_box();
+
+    // 4. Auto-frame camera: position at 2.5x bounding radius along +Z.
+    auto [center, radius] = compute_centroid_and_radius(*tri_mesh);
+    double cam_dist = radius * 2.5;
+    art::Vector3d eye_vec = center + art::Vector3d({0.0, 0.0, cam_dist});
+
+    art::Camera cam(art::Camera::lookAt(
+        art::Point(eye_vec), art::Point(center), art::Point(0, 1, 0)));
+
+    // 5. Ray trace.
+    spdlog::info("Rendering {}x{} ...", width, height);
+    art::Image image = cam.render(width, height, obj);
+
+    // 6. Convert to RGBA8 and output to terminal.
+    auto rgba8 = image.to_rgba8();
+    balsa::terminal::emit_auto(width, height, rgba8);
+
+    // Also save as PPM for reference.
+    auto save_result = art::io::save(mesh_path.stem().string() + ".ppm", image);
+    if (!save_result) {
+        spdlog::warn("Failed to save PPM: {}",
+                     mesh_path.stem().string() + ".ppm");
+    }
+
+    return 0;
+}

--- a/tools/meson.build
+++ b/tools/meson.build
@@ -1,0 +1,2 @@
+art_term = executable('art_term', 'art_term.cpp',
+  dependencies: [art_dep, balsaCore_dep, quiver_dep] + internal_deps)


### PR DESCRIPTION
## Summary

- Add Image class (PBRT Film-style pixel buffer with sample accumulation, tone mapping, progress tracking)
- Add Image I/O layer (PPM always, EXR/PNG optional via `-Dexr=true`/`-Dpng=true`)
- Add TriangleMesh geometry with Moller-Trumbore intersection
- Add `art_term` CLI tool: loads mesh via quiver, ray-traces with auto-framed camera, outputs to terminal

## Dependencies

- **quiver** is now a required dependency (mesh I/O and topology)
- **balsa** is an optional dependency gated behind `-Dviewer=true` (terminal output)
- Depends on: [balsa PR #10](https://github.com/mtao/balsa/pull/10) for `balsa::terminal::emit_auto()`

## Build

```bash
# Core library only (no terminal viewer)
meson setup build-debug --buildtype=debug -Dtesting=false
meson compile -C build-debug

# With terminal viewer tool
meson setup build-debug --buildtype=debug -Dviewer=true
meson compile -C build-debug

# Usage
./build-debug/tools/art_term model.obj [width] [height]
```

## Fixes included

- Fixed `zipper/transform/transform.hpp` -> `zipper/transform/all.hpp` (renamed upstream)
- Fixed spdlog/fmt define conflict by building spdlog as static
- `exr.cpp`/`png.cpp` always compiled with stub fallbacks when optional deps are absent

## Known limitations

- Linear-scan intersection (no BVH) — slow for large meshes (>1000 triangles at high resolution)
- Camera FOV is hardcoded (~53 degrees)
- No materials, lights, or color — headlight diffuse shading only